### PR TITLE
Add support for serde attributes skip and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ Supported serde attributes:
 - `tag`
 - `content`
 - `untagged`
+- `skip`
 - `skip_serializing`
 - `skip_deserializing`
 - `flatten`
+- `default`
 
 ## todo
 - [x] serde compatibility layer

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -58,8 +58,14 @@ impl_parse! {
 impl_parse! {
     SerdeFieldAttr(input, out) {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
+        "skip" => out.0.skip = true,
         "skip_serializing" => out.0.skip = true,
         "skip_deserializing" => out.0.skip = true,
         "flatten" => out.0.flatten = true,
+        "default" => {
+            if !input.is_empty() {
+                parse_assign_str(input)?;
+            }
+        },
     }
 }


### PR DESCRIPTION
Hi,
thanks for your work on ts-rs. Currently serde attributes `skip` and `default` generate warnings like
```
warning: failed to parse serde attribute
  | 
  | #[serde(default)]
  | 
  = note: ts-rs failed to parse this attribute. It will be ignored.
```
Adding support for them seemed easy enough so I gave it a go.

Since `skip_serializing` and `skip_deserializing` are supported and do the same thing, I just copied the functionality for `skip`.
I figure `default` doesn't have any implications for ts-rs, so I made it a no-op. I'm not sure if checking for input and calling `parse_assing_str` is the best way to skip over it though.

Let me know if this looks like a good idea and if there are any changes you'd like.