### PR TITLE
Implement internally tagged unions

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -30,11 +30,19 @@ struct User {
     gender: Gender,
 }
 
+#[derive(Serialize, TS)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Vehicle {
+    Bicycle { color: String },
+    Car { brand: String, color: String },
+}
+
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
 // `export!` will also take care of including imports in typescript files.
 export! {
     Role => "role.ts",
     User => "user.ts",
+    Vehicle => "vehicle.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",
 }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -95,7 +95,8 @@ fn format_variant(
                 None => match derived_type.inline_flattened {
                     Some(inline_flattened) => quote! {
                         format!(
-                            "{{\n{}: \"{}\",\n{}}}",
+                            "{{\n{}{}: \"{}\",\n{}\n}}",
+                            " ".repeat((indent + 1) * 4),
                             #tag,
                             #name,
                             #inline_flattened

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -82,7 +82,8 @@ fn format_variant(
         _ => {}
     };
 
-    let inline_type = type_def(&name, &None, &variant.fields)?.inline;
+    let derived_type = type_def(&name, &None, &variant.fields)?;
+    let inline_type = derived_type.inline;
 
     formatted_variants.push(match &enum_attr.untag {
         true => quote!(#inline_type),
@@ -91,7 +92,19 @@ fn format_variant(
                 Some(content) => {
                     quote!(format!("{{{}: \"{}\", {}: {}}}", #tag, #name, #content, #inline_type))
                 }
-                None => panic!("Serde enums with tag discriminators should also have content keys"),
+                None => match derived_type.inline_flattened {
+                    Some(inline_flattened) => quote! {
+                        format!(
+                            "{{\n{}: \"{}\",\n{}}}",
+                            #tag,
+                            #name,
+                            #inline_flattened
+                        )
+                    },
+                    None => panic!(
+                        "Serde enums with tag discriminators should also have flattened fields"
+                    ),
+                },
             },
             None => match &variant.fields {
                 Fields::Unit => quote!(format!("\"{}\"", #name)),

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -1,0 +1,25 @@
+#![allow(dead_code)]
+
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, TS)]
+#[serde(tag = "type")]
+enum EnumWithInternalTag {
+    A { foo: String },
+    B { bar: i32 },
+}
+
+#[test]
+fn test_enum_with_internal_tag() {
+    assert_eq!(
+        EnumWithInternalTag::decl(),
+        r#"type EnumWithInternalTag = {
+    type: "A",
+    foo: string,
+} | {
+    type: "B",
+    bar: number,
+};"#
+    )
+}


### PR DESCRIPTION
This PR implements support for internally tagged unions: https://serde.rs/enum-representations.html#internally-tagged

This type definition:

```rs
#[derive(Serialize, TS)]
#[serde(tag = "type", rename_all = "snake_case")]
enum Vehicle {
    Bicycle { color: String },
    Car { brand: String, color: String }
}
```

yields the following TypeScript definition:

```ts
export type Vehicle = {
  type: "bicycle";
  color: string;
} | {
  type: "car";
  brand: string;
  color: string;
};
```

To be honest, implementation-wise I'm still having trouble wrapping my head around the `quote!()` macro, so if anything is off, please let me know :)