### PR TITLE
Implement internally tagged unions with subtypes

### DIFF
--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -102,9 +102,15 @@ fn format_variant(
                             #inline_flattened
                         )
                     },
-                    None => panic!(
-                        "Serde enums with tag discriminators should also have flattened fields"
-                    ),
+                    None => quote! {
+                        format!(
+                            "\n{}{{ {}: \"{}\" }} & {}",
+                            " ".repeat((indent + 1) * 4),
+                            #tag,
+                            #name,
+                            #inline_type
+                        )
+                    },
                 },
             },
             None => match &variant.fields {

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -37,21 +37,32 @@ pub(crate) fn r#enum(s: &ItemEnum) -> Result<DerivedTS> {
     };
 
     let mut formatted_variants = vec![];
+    let mut dependencies = vec![];
     for variant in &s.variants {
-        format_variant(&mut formatted_variants, &enum_attr, &variant)?;
+        format_variant(
+            &mut formatted_variants,
+            &mut dependencies,
+            &enum_attr,
+            &variant,
+        )?;
     }
 
     Ok(DerivedTS {
         inline: quote!(vec![#(#formatted_variants),*].join(" | ")),
         decl: quote!(format!("type {} = {};", #name, Self::inline(0))),
         inline_flattened: None,
-        dependencies: quote!((vec![])),
+        dependencies: quote! {
+            let mut dependencies = vec![];
+            #( #dependencies )*
+            dependencies
+        },
         name,
     })
 }
 
 fn format_variant(
     formatted_variants: &mut Vec<TokenStream>,
+    dependencies: &mut Vec<TokenStream>,
     enum_attr: &EnumAttr,
     variant: &Variant,
 ) -> Result<()> {
@@ -84,6 +95,7 @@ fn format_variant(
 
     let derived_type = type_def(&name, &None, &variant.fields)?;
     let inline_type = derived_type.inline;
+    let derived_dependencies = derived_type.dependencies;
 
     formatted_variants.push(match &enum_attr.untag {
         true => quote!(#inline_type),
@@ -102,15 +114,18 @@ fn format_variant(
                             #inline_flattened
                         )
                     },
-                    None => quote! {
-                        format!(
-                            "\n{}{{ {}: \"{}\" }} & {}",
-                            " ".repeat((indent + 1) * 4),
-                            #tag,
-                            #name,
-                            #inline_type
-                        )
-                    },
+                    None => {
+                        dependencies.push(quote!(dependencies.append(&mut #derived_dependencies);));
+                        quote! {
+                            format!(
+                                "\n{}{{ {}: \"{}\" }} & {}",
+                                " ".repeat((indent + 1) * 4),
+                                #tag,
+                                #name,
+                                #inline_type
+                            )
+                        }
+                    }
                 },
             },
             None => match &variant.fields {

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -10,8 +10,25 @@ enum EnumWithInternalTag {
     B { bar: i32 },
 }
 
+#[derive(Serialize, TS)]
+struct InnerA {
+    foo: String,
+}
+
+#[derive(Serialize, TS)]
+struct InnerB {
+    bar: i32,
+}
+
+#[derive(Serialize, TS)]
+#[serde(tag = "type")]
+enum EnumWithInternalTag2 {
+    A(InnerA),
+    B(InnerB),
+}
+
 #[test]
-fn test_enum_with_internal_tag() {
+fn test_enums_with_internal_tags() {
     assert_eq!(
         EnumWithInternalTag::decl(),
         r#"type EnumWithInternalTag = {
@@ -21,5 +38,12 @@ fn test_enum_with_internal_tag() {
     type: "B",
     bar: number,
 };"#
-    )
+    );
+
+    assert_eq!(
+        EnumWithInternalTag2::decl(),
+        r#"type EnumWithInternalTag2 = 
+    { type: "A" } & InnerA | 
+    { type: "B" } & InnerB;"#
+    );
 }


### PR DESCRIPTION
I have a follow-up PR :)

It now also allows for the use of subtypes inside internally tagged unions.