### PR TITLE
Optional options

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -37,11 +37,28 @@ enum Vehicle {
     Car { brand: String, color: String },
 }
 
+#[derive(Serialize, TS)]
+struct Point<T>
+where
+    T: TS,
+{
+    time: u64,
+    value: T,
+}
+
+#[derive(Serialize, TS)]
+struct Series {
+    points: Vec<Point<u64>>,
+}
+
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
 // `export!` will also take care of including imports in typescript files.
 export! {
     Role => "role.ts",
     User => "user.ts",
+    // any type can be used here in place of the generic, as long as it impls TS:
+    Point<()> => "point.ts",
+    Series => "series.ts",
     Vehicle => "vehicle.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -10,6 +10,7 @@ pub struct FieldAttr {
     pub rename: Option<String>,
     pub inline: bool,
     pub skip: bool,
+    pub optional: bool,
     pub flatten: bool,
 }
 
@@ -33,6 +34,7 @@ impl FieldAttr {
             rename,
             inline,
             skip,
+            optional,
             flatten,
         }: FieldAttr,
     ) {
@@ -40,6 +42,7 @@ impl FieldAttr {
         self.type_override = self.type_override.take().or(type_override);
         self.inline = self.inline || inline;
         self.skip = self.skip || skip;
+        self.optional |= optional;
         self.flatten |= flatten;
     }
 }
@@ -50,6 +53,7 @@ impl_parse! {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "inline" => out.inline = true,
         "skip" => out.skip = true,
+        "optional" => out.optional = true,
         "flatten" => out.flatten = true,
     }
 }
@@ -60,6 +64,7 @@ impl_parse! {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "skip_serializing" => out.0.skip = true,
         "skip_deserializing" => out.0.skip = true,
+        "skip_serializing_if" => out.0.optional = parse_assign_str(input)? == *"Option::is_none",
         "flatten" => out.0.flatten = true,
     }
 }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -102,9 +102,15 @@ fn format_variant(
                             #inline_flattened
                         )
                     },
-                    None => panic!(
-                        "Serde enums with tag discriminators should also have flattened fields"
-                    ),
+                    None => quote! {
+                        format!(
+                            "\n{}{{ {}: \"{}\" }} & {}",
+                            " ".repeat((indent + 1) * 4),
+                            #tag,
+                            #name,
+                            #inline_type
+                        )
+                    },
                 },
             },
             None => match &variant.fields {

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -65,13 +65,15 @@ fn format_variant(
         rename,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&variant.attrs)?;
 
-    match (skip, &type_override, inline, flatten) {
+    match (skip, &type_override, inline, optional, flatten) {
         (true, ..) => return Ok(()),
         (_, Some(_), ..) => syn_err!("`type_override` is not applicable to enum variants"),
-        (_, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
+        (_, _, _, true, ..) => syn_err!("`optional` is not applicable to enum variants"),
+        (_, _, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
         _ => {}
     };
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,6 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Field, FieldsNamed, Result};
+use syn::{
+    Field, FieldsNamed, GenericArgument, GenericParam, Generics, Ident, Path, PathArguments,
+    PathSegment, Result, Type,
+};
 
 use crate::attr::{FieldAttr, Inflection};
 use crate::DerivedTS;
@@ -9,14 +12,35 @@ pub(crate) fn named(
     name: &str,
     rename_all: &Option<Inflection>,
     fields: &FieldsNamed,
+    generics: &Generics,
 ) -> Result<DerivedTS> {
     let mut formatted_fields = vec![];
     let mut dependencies = vec![];
     for field in &fields.named {
-        format_field(&mut formatted_fields, &mut dependencies, field, &rename_all)?;
+        format_field(
+            &mut formatted_fields,
+            &mut dependencies,
+            field,
+            &rename_all,
+            generics,
+        )?;
     }
 
     let fields = quote!(vec![#(#formatted_fields),*].join("\n"));
+    let generic_args = match &generics.params {
+        params if !params.is_empty() => {
+            let expanded_params = params
+                .iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            quote!(format!("<{}>", #expanded_params))
+        }
+        _ => quote!("".to_owned()),
+    };
 
     Ok(DerivedTS {
         inline: quote! {
@@ -26,7 +50,7 @@ pub(crate) fn named(
                 " ".repeat(indent * 4)
             )
         },
-        decl: quote!(format!("interface {} {}", #name, Self::inline(0))),
+        decl: quote!(format!("interface {}{} {}", #name, #generic_args, Self::inline(0))),
         inline_flattened: Some(fields),
         name: name.to_owned(),
         dependencies: quote! {
@@ -43,6 +67,7 @@ fn format_field(
     dependencies: &mut Vec<TokenStream>,
     field: &Field,
     rename_all: &Option<Inflection>,
+    generics: &Generics,
 ) -> Result<()> {
     let FieldAttr {
         type_override,
@@ -84,11 +109,63 @@ fn format_field(
         });
     }
 
-    let formatted_ty = type_override
-        .map(|t| quote!(#t))
-        .unwrap_or_else(|| match inline {
-            true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
-            false => quote!(<#ty as ts_rs::TS>::name()),
+    let formatted_ty =
+        type_override.map(|t| quote!(#t)).unwrap_or_else(|| {
+            if let Some(generic_ident) = generics
+                .params
+                .iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(type_param) => Some(type_param),
+                    _ => None,
+                })
+                .find(|type_param| {
+                    matches!(
+                        ty,
+                        Type::Path(type_path)
+                            if type_path.qself.is_none()
+                            && type_path.path == Path::from(PathSegment {
+                                ident: type_param.ident.clone(),
+                                arguments: PathArguments::None,
+                            })
+                    )
+                })
+                .map(|type_param| type_param.ident.to_string())
+            {
+                quote!(#generic_ident)
+            } else if let Some((name, generic_args)) =
+                match ty {
+                    Type::Path(type_path) => type_path.path.segments.last().and_then(|segment| {
+                        match &segment.arguments {
+                            PathArguments::AngleBracketed(generic_arguments) => {
+                                if has_specialized_impl(&segment.ident) {
+                                    None
+                                } else {
+                                    Some((segment.ident.to_string(), &generic_arguments.args))
+                                }
+                            }
+                            _ => None,
+                        }
+                    }),
+                    _ => None,
+                }
+            {
+                let args = generic_args
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        GenericArgument::Type(Type::Path(type_path)) => {
+                            let path = &type_path.path;
+                            Some(quote!(<#path as ts_rs::TS>::name()))
+                        }
+                        _ => None,
+                    })
+                    .collect::<TokenStream>();
+                quote!(format!("{}<{}>", #name, #args))
+            } else {
+                match inline {
+                    true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
+                    false => quote!(<#ty as ts_rs::TS>::name()),
+                }
+            }
         });
     let name = match (rename, rename_all) {
         (Some(rn), _) => rn,
@@ -101,4 +178,19 @@ fn format_field(
     });
 
     Ok(())
+}
+
+fn has_specialized_impl(ident: &Ident) -> bool {
+    ident == "Arc"
+        || ident == "Box"
+        || ident == "BTreeMap"
+        || ident == "BTreeSet"
+        || ident == "Cell"
+        || ident == "Cow"
+        || ident == "HashMap"
+        || ident == "HashSet"
+        || ident == "Option"
+        || ident == "Rc"
+        || ident == "RefCell"
+        || ident == "Vec"
 }

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -18,13 +18,15 @@ pub(crate) fn newtype(
         rename: rename_inner,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&inner.attrs)?;
 
-    match (&rename_inner, skip, flatten) {
-        (Some(_), _, _) => syn_err!("`rename` is not applicable to newtype fields"),
-        (_, true, _) => syn_err!("`skip` is not applicable to newtype fields"),
-        (_, _, true) => syn_err!("`flatten` is not applicable to newtype fields"),
+    match (&rename_inner, skip, optional, flatten) {
+        (Some(_), ..) => syn_err!("`rename` is not applicable to newtype fields"),
+        (_, true, ..) => syn_err!("`skip` is not applicable to newtype fields"),
+        (_, _, true, ..) => syn_err!("`optional` is not applicable to newtype fields"),
+        (_, _, _, true) => syn_err!("`flatten` is not applicable to newtype fields"),
         _ => {}
     };
 

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -55,6 +55,7 @@ fn format_field(
         rename,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&field.attrs)?;
 
@@ -63,6 +64,9 @@ fn format_field(
     }
     if rename.is_some() {
         syn_err!("`rename` is not applicable to tuple structs")
+    }
+    if optional {
+        syn_err!("`optional` is not applicable to tuple fields")
     }
     if flatten {
         syn_err!("`flatten` is not applicable to tuple fields")

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -84,6 +84,9 @@ pub mod export;
 /// - `#[ts(skip)]`:  
 ///   Skip this field  
 ///
+/// - `#[ts(optional)]
+///   Indicates the field may be omitted from the serialized struct
+///
 /// - `#[ts(flatten)]`:  
 ///   Flatten this field (only works if the field is a struct)  
 ///   

--- a/ts-rs/tests/generic_struct.rs
+++ b/ts-rs/tests/generic_struct.rs
@@ -1,0 +1,35 @@
+#![allow(dead_code)]
+
+use ts_rs::TS;
+
+#[derive(TS)]
+struct Generic<T>
+where
+    T: TS,
+{
+    value: T,
+}
+
+#[derive(TS)]
+struct Container {
+    foo: Generic<u32>,
+}
+
+#[test]
+fn test() {
+    assert_eq!(
+        Generic::<()>::decl(),
+        "\
+interface Generic<T> {
+    value: T,
+}"
+    );
+
+    assert_eq!(
+        Container::decl(),
+        "\
+interface Container {
+    foo: Generic<number>,
+}"
+    );
+}

--- a/ts-rs/tests/optional_field.rs
+++ b/ts-rs/tests/optional_field.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, TS)]
+struct Optional {
+    #[ts(optional)]
+    a: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b: Option<String>,
+}
+
+#[test]
+fn test() {
+    assert_eq!(
+        Optional::inline(0),
+        "\
+{
+    a?: number,
+    b?: string,
+}"
+    )
+}

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -10,8 +10,25 @@ enum EnumWithInternalTag {
     B { bar: i32 },
 }
 
+#[derive(Serialize, TS)]
+struct InnerA {
+    foo: String,
+}
+
+#[derive(Serialize, TS)]
+struct InnerB {
+    bar: i32,
+}
+
+#[derive(Serialize, TS)]
+#[serde(tag = "type")]
+enum EnumWithInternalTag2 {
+    A(InnerA),
+    B(InnerB),
+}
+
 #[test]
-fn test_enum_with_internal_tag() {
+fn test_enums_with_internal_tags() {
     assert_eq!(
         EnumWithInternalTag::decl(),
         r#"type EnumWithInternalTag = {
@@ -21,5 +38,12 @@ fn test_enum_with_internal_tag() {
     type: "B",
     bar: number,
 };"#
-    )
+    );
+
+    assert_eq!(
+        EnumWithInternalTag2::decl(),
+        r#"type EnumWithInternalTag2 = 
+    { type: "A" } & InnerA | 
+    { type: "B" } & InnerB;"#
+    );
 }


### PR DESCRIPTION
Currently, `ts-rs` translates `foo: Option<T>` to `foo: T | null` in TypeScript, but a common pattern is to use `#[serde(skip_serializing_if="Option::is_none")]` for types that are represented in TypeScript like this: `foo?: T`. It's a rather specific feature, but one that is very valuable for our usecase.

Note: This PR includes my other PRs, as I want to save myself the merge conflicts, so you may want to just look at the last commit. If necessary, I can split them out later.