### PR TITLE
Optional Options (part II)

### DIFF
--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -10,6 +10,7 @@ pub struct FieldAttr {
     pub rename: Option<String>,
     pub inline: bool,
     pub skip: bool,
+    pub optional: bool,
     pub flatten: bool,
 }
 
@@ -33,6 +34,7 @@ impl FieldAttr {
             rename,
             inline,
             skip,
+            optional,
             flatten,
         }: FieldAttr,
     ) {
@@ -40,6 +42,7 @@ impl FieldAttr {
         self.type_override = self.type_override.take().or(type_override);
         self.inline = self.inline || inline;
         self.skip = self.skip || skip;
+        self.optional |= optional;
         self.flatten |= flatten;
     }
 }
@@ -50,6 +53,7 @@ impl_parse! {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "inline" => out.inline = true,
         "skip" => out.skip = true,
+        "optional" => out.optional = true,
         "flatten" => out.flatten = true,
     }
 }
@@ -60,6 +64,7 @@ impl_parse! {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "skip_serializing" => out.0.skip = true,
         "skip_deserializing" => out.0.skip = true,
+        "skip_serializing_if" => out.0.optional = parse_assign_str(input)? == *"Option::is_none",
         "flatten" => out.0.flatten = true,
     }
 }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -60,13 +60,15 @@ fn format_variant(
         rename,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&variant.attrs)?;
 
-    match (skip, &type_override, inline, flatten) {
+    match (skip, &type_override, inline, optional, flatten) {
         (true, ..) => return Ok(()),
         (_, Some(_), ..) => syn_err!("`type_override` is not applicable to enum variants"),
-        (_, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
+        (_, _, _, true, ..) => syn_err!("`optional` is not applicable to enum variants"),
+        (_, _, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
         _ => {}
     };
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -57,11 +57,10 @@ fn format_field(
         return Ok(());
     }
 
-    let mut ty = &field.ty;
-
-    if optional {
-        ty = extract_option_argument(ty)?;
-    }
+    let (ty, optional_annotation) = match optional {
+        true => (extract_option_argument(&field.ty)?, "?"),
+        false => (&field.ty, ""),
+    };
 
     if flatten {
         match (&type_override, &rename, inline) {
@@ -100,7 +99,6 @@ fn format_field(
         (None, Some(rn)) => rn.apply(&field.ident.as_ref().unwrap().to_string()),
         (None, None) => field.ident.as_ref().unwrap().to_string(),
     };
-    let optional_annotation = if optional { "?" } else { "" };
 
     formatted_fields.push(quote! {
         format!("{}{}{}: {},", " ".repeat((indent + 1) * 4), #name, #optional_annotation, #formatted_ty)

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Field, FieldsNamed, Result};
+use syn::{Field, FieldsNamed, GenericArgument, PathArguments, Result, Type};
 
 use crate::attr::{FieldAttr, Inflection};
 use crate::DerivedTS;
@@ -49,6 +49,7 @@ fn format_field(
         rename,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&field.attrs)?;
 
@@ -56,7 +57,11 @@ fn format_field(
         return Ok(());
     }
 
-    let ty = &field.ty;
+    let mut ty = &field.ty;
+
+    if optional {
+        ty = extract_option_argument(ty)?;
+    }
 
     if flatten {
         match (&type_override, &rename, inline) {
@@ -95,10 +100,34 @@ fn format_field(
         (None, Some(rn)) => rn.apply(&field.ident.as_ref().unwrap().to_string()),
         (None, None) => field.ident.as_ref().unwrap().to_string(),
     };
+    let optional_annotation = if optional { "?" } else { "" };
 
     formatted_fields.push(quote! {
-        format!("{}{}: {},", " ".repeat((indent + 1) * 4), #name, #formatted_ty)
+        format!("{}{}{}: {},", " ".repeat((indent + 1) * 4), #name, #optional_annotation, #formatted_ty)
     });
 
     Ok(())
+}
+
+fn extract_option_argument(ty: &Type) -> Result<&Type> {
+    match ty {
+        Type::Path(type_path)
+            if type_path.qself.is_none()
+                && type_path.path.leading_colon.is_none()
+                && type_path.path.segments.len() == 1
+                && type_path.path.segments[0].ident == "Option" =>
+        {
+            let segment = &type_path.path.segments[0];
+            match &segment.arguments {
+                PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
+                    match &args.args[0] {
+                        GenericArgument::Type(inner_ty) => Ok(&inner_ty),
+                        _ => syn_err!("`Option` argument must be a type"),
+                    }
+                }
+                _ => syn_err!("`Option` type must have a single generic argument"),
+            }
+        }
+        _ => syn_err!("`optional` can only be used on an Option<T> type"),
+    }
 }

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -18,13 +18,15 @@ pub(crate) fn newtype(
         rename: rename_inner,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&inner.attrs)?;
 
-    match (&rename_inner, skip, flatten) {
-        (Some(_), _, _) => syn_err!("`rename` is not applicable to newtype fields"),
-        (_, true, _) => syn_err!("`skip` is not applicable to newtype fields"),
-        (_, _, true) => syn_err!("`flatten` is not applicable to newtype fields"),
+    match (&rename_inner, skip, optional, flatten) {
+        (Some(_), ..) => syn_err!("`rename` is not applicable to newtype fields"),
+        (_, true, ..) => syn_err!("`skip` is not applicable to newtype fields"),
+        (_, _, true, ..) => syn_err!("`optional` is not applicable to newtype fields"),
+        (_, _, _, true) => syn_err!("`flatten` is not applicable to newtype fields"),
         _ => {}
     };
 

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -55,6 +55,7 @@ fn format_field(
         rename,
         inline,
         skip,
+        optional,
         flatten,
     } = FieldAttr::from_attrs(&field.attrs)?;
 
@@ -63,6 +64,9 @@ fn format_field(
     }
     if rename.is_some() {
         syn_err!("`rename` is not applicable to tuple structs")
+    }
+    if optional {
+        syn_err!("`optional` is not applicable to tuple fields")
     }
     if flatten {
         syn_err!("`flatten` is not applicable to tuple fields")

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -84,6 +84,9 @@ pub mod export;
 /// - `#[ts(skip)]`:  
 ///   Skip this field  
 ///
+/// - `#[ts(optional)]
+///   Indicates the field may be omitted from the serialized struct
+///
 /// - `#[ts(flatten)]`:  
 ///   Flatten this field (only works if the field is a struct)  
 ///   

--- a/ts-rs/tests/optional_field.rs
+++ b/ts-rs/tests/optional_field.rs
@@ -1,0 +1,24 @@
+#![allow(dead_code)]
+
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, TS)]
+struct Optional {
+    #[ts(optional)]
+    a: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b: Option<String>,
+}
+
+#[test]
+fn test() {
+    assert_eq!(
+        Optional::inline(0),
+        "\
+{
+    a?: number,
+    b?: string,
+}"
+    )
+}


### PR DESCRIPTION
Currently, `ts-rs` translates `foo: Option<T>` to `foo: T | null` in TypeScript, but a common pattern is to use `#[serde(skip_serializing_if="Option::is_none")]` for types that are represented in TypeScript like this: `foo?: T`. It's a rather specific feature, but one that is very valuable for our usecase.

(I have recreated this PR so it doesn't include commits from other PRs)