### PR TITLE
Generate index

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -31,6 +31,8 @@ pub use ts_rs_macros::TS;
 #[doc(hidden)]
 pub mod export;
 
+pub use export::index;
+
 /// A type which can be represented in TypeScript.  
 /// Most of the time, you'd want to derive this trait instead of implementing it manually.  
 /// ts-rs comes with implementations for all numeric types, `String`, `Vec`, `Option` and tuples.


### PR DESCRIPTION
This implements the ability for the `export!` macro to generate an index file that simply re-exports all the generated type definitions.

Example:

```rust
use ts_rs::{export, index};

export ! {
    A => "bindings/a.ts",
    index => "bindings/index.ts" // export type { A } from "./a.ts";
}
```


PS.: This might be my last PR for a little while, as it appears our use case has now been successfully implemented :)