### PR TITLE
add #[ts(type=..)] on enums for `enum` generation

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -10,6 +10,7 @@ pub struct EnumAttr {
     pub tag: Option<String>,
     pub untag: bool,
     pub content: Option<String>,
+    pub r#type: Option<String>
 }
 
 #[cfg(feature = "serde-compat")]
@@ -33,8 +34,10 @@ impl EnumAttr {
             tag,
             content,
             untag,
+            r#type
         }: EnumAttr,
     ) {
+        self.r#type = self.r#type.take().or(r#type);
         self.rename = self.rename.take().or(rename);
         self.rename_all = self.rename_all.take().or(rename_all);
         self.tag = self.tag.take().or(tag);
@@ -47,6 +50,7 @@ impl_parse! {
     EnumAttr(input, out) {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
+        "type" => out.r#type = Some(parse_assign_str(input)?)
     }
 }
 
@@ -57,6 +61,7 @@ impl_parse! {
         "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "tag" => out.0.tag = Some(parse_assign_str(input)?),
         "content" => out.0.content = Some(parse_assign_str(input)?),
-        "untagged" => out.0.untag = true
+        "untagged" => out.0.untag = true,
+        "type" => out.0.r#type = Some(parse_assign_str(input)?)
     }
 }

--- a/ts-rs/tests/rename_enum_type.rs
+++ b/ts-rs/tests/rename_enum_type.rs
@@ -1,0 +1,124 @@
+#![allow(dead_code)]
+
+use serde::Deserialize;
+use ts_rs::TS;
+
+#[derive(TS, Deserialize)]
+#[ts(type="const enum")]
+enum SimpleConstEnum {
+    #[serde(rename="a")]
+    A,
+    B,
+}
+
+#[test]
+fn const_enum() {
+    assert_eq!(
+        SimpleConstEnum::decl(),
+        r#"const enum SimpleConstEnum {A="a", B="B"}"#
+    );
+}
+
+
+#[derive(TS, Deserialize)]
+#[ts(type="enum")]
+enum SimpleEnum {
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum() {
+    assert_eq!(
+        SimpleEnum::decl(),
+        r#"enum SimpleEnum {A, B}"#
+    );
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type="enum")]
+enum EnumWithBothNumberAndARename {
+    A=1,
+    #[serde(rename="XD")]
+    B,
+}
+
+#[test]
+fn enum_with_both_number_and_rename() {
+    assert_eq!(
+        EnumWithBothNumberAndARename::decl(),
+        r#"enum EnumWithBothNumberAndARename {A=1, B="XD"}"#
+    );
+}
+
+
+#[derive(TS, Deserialize)]
+#[ts(type="enum")]
+enum SimpleEnumWithNumberAssigned {
+    A=1,
+    B,
+}
+
+#[test]
+fn simple_enum_discriminant() {
+    assert_eq!(
+        SimpleEnumWithNumberAssigned::decl(),
+        r#"enum SimpleEnumWithNumberAssigned {A=1, B}"#
+    )
+}
+
+
+#[derive(TS, Deserialize)]
+#[ts(type="enum")]
+enum SimpleEnumWithRename {
+    #[serde(rename="a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_variant_rename() {
+    assert_eq!(
+        SimpleEnumWithRename::decl(),
+        r#"enum SimpleEnumWithRename {A="a", B="B"}"#
+    );
+}
+
+
+#[derive(TS, Deserialize)]
+#[ts(type="enum")]
+#[serde(rename_all="lowercase")]
+enum SimpleEnumWithInflection {
+    #[serde(rename="a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_inflection() {
+    assert_eq!(
+        SimpleEnumWithInflection::decl(),
+        r#"enum SimpleEnumWithInflection {A="a", B="b"}"#
+    );
+}
+
+
+#[derive(TS, Deserialize)]
+// #[ts(type="type")]
+enum SimpleEnumNotChanged {
+    #[serde(rename="a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_not_changed() {
+    assert_eq!(
+        SimpleEnumNotChanged::decl(),
+        r#"type SimpleEnumNotChanged = "a" | "B";"#
+    );
+}
+
+
+
+


### PR DESCRIPTION
Previously having even a simple enum would generate a `type`. The default behavior does not change, but if specifed to be `enum` or `const enum` the corresponding will be generated.

Closes #23 