### PR TITLE
Generics support (part III)

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 ts-rs = { path = "../ts-rs" }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use serde::Serialize;
+use std::collections::BTreeSet;
+use std::rc::Rc;
 use ts_rs::{export, TS};
 
 #[derive(Serialize, TS)]
@@ -80,18 +82,27 @@ enum InlineComplexEnum {
     U(Box<User>),
 }
 
+#[derive(Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+struct ComplexStruct {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub string_tree: Option<Rc<BTreeSet<String>>>,
+}
+
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
 // `export!` will also take care of including imports in typescript files.
 export! {
     Role => "role.ts",
     User => "user.ts",
-    // any type can be used here in place of the generic, as long as it impls TS:
-    Point<()> => "point.ts",
+    // any type can be used here in place of the generic, but it has to match the one used
+    // in other structs to generate the dependencies correctly:
+    Point<u64> => "point.ts",
     Series => "series.ts",
     Vehicle => "vehicle.ts",
     ComplexEnum => "complex_enum.ts",
     InlineComplexEnum => "inline_complex_enum.ts",
     SimpleEnum => "simple_enum.ts",
+    ComplexStruct => "complex_struct.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -51,6 +51,24 @@ struct Series {
     points: Vec<Point<u64>>,
 }
 
+#[derive(Serialize, TS)]
+#[serde(tag = "kind", content = "d")]
+enum SimpleEnum {
+    A,
+    B,
+}
+
+#[derive(Serialize, TS)]
+#[serde(tag = "kind", content = "data")]
+enum ComplexEnum {
+    A,
+    B { foo: String, bar: f64 },
+    W(SimpleEnum),
+    F { nested: SimpleEnum },
+    T(i32, SimpleEnum),
+    V(Vec<Series>),
+}
+
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
 // `export!` will also take care of including imports in typescript files.
 export! {
@@ -60,6 +78,8 @@ export! {
     Point<()> => "point.ts",
     Series => "series.ts",
     Vehicle => "vehicle.ts",
+    ComplexEnum => "complex_enum.ts",
+    SimpleEnum => "simple_enum.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -65,8 +65,19 @@ enum ComplexEnum {
     B { foo: String, bar: f64 },
     W(SimpleEnum),
     F { nested: SimpleEnum },
-    T(i32, SimpleEnum),
     V(Vec<Series>),
+    U(Box<User>),
+}
+
+#[derive(Serialize, TS)]
+#[serde(tag = "kind")]
+enum InlineComplexEnum {
+    A,
+    B { foo: String, bar: f64 },
+    W(SimpleEnum),
+    F { nested: SimpleEnum },
+    V(Vec<Series>),
+    U(Box<User>),
 }
 
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
@@ -79,6 +90,7 @@ export! {
     Series => "series.ts",
     Vehicle => "vehicle.ts",
     ComplexEnum => "complex_enum.ts",
+    InlineComplexEnum => "inline_complex_enum.ts",
     SimpleEnum => "simple_enum.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -37,11 +37,28 @@ enum Vehicle {
     Car { brand: String, color: String },
 }
 
+#[derive(Serialize, TS)]
+struct Point<T>
+where
+    T: TS,
+{
+    time: u64,
+    value: T,
+}
+
+#[derive(Serialize, TS)]
+struct Series {
+    points: Vec<Point<u64>>,
+}
+
 // this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
 // `export!` will also take care of including imports in typescript files.
 export! {
     Role => "role.ts",
     User => "user.ts",
+    // any type can be used here in place of the generic, as long as it impls TS:
+    Point<()> => "point.ts",
+    Series => "series.ts",
     Vehicle => "vehicle.ts",
     // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
     (declare) Gender => "gender.d.ts",

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -1,0 +1,76 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{GenericArgument, GenericParam, Generics, PathArguments, Type};
+
+pub fn format_type(
+    ty: &Type,
+    dependencies: &mut Vec<TokenStream>,
+    generics: &Generics,
+) -> TokenStream {
+    // If the type matches one of the generic parameters, just pass the identifier:
+    if let Some(generic_ident) = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            GenericParam::Type(type_param) => Some(type_param),
+            _ => None,
+        })
+        .find(|type_param| {
+            matches!(
+                ty,
+                Type::Path(type_path)
+                    if type_path.qself.is_none()
+                    && type_path.path.is_ident(&type_param.ident)
+            )
+        })
+        .map(|type_param| type_param.ident.to_string())
+    {
+        return quote!(#generic_ident.to_owned());
+    }
+
+    dependencies.push(quote! {
+        if <#ty as ts_rs::TS>::transparent() {
+            dependencies.append(&mut <#ty as ts_rs::TS>::dependencies());
+        } else {
+            dependencies.push((std::any::TypeId::of::<#ty>(), <#ty as ts_rs::TS>::name()));
+        }
+    });
+
+    match extract_type_args(ty) {
+        None => quote!(<#ty as ts_rs::TS>::name()),
+        Some(type_args) => {
+            let args = type_args
+                .iter()
+                .map(|ty| format_type(ty, dependencies, generics))
+                .collect::<Vec<_>>();
+            let args = quote!(vec![#(#args),*]);
+            quote!(<#ty as ts_rs::TS>::name_with_type_args(#args))
+        }
+    }
+}
+
+fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
+    let last_segment = match ty {
+        Type::Path(type_path) => type_path.path.segments.last(),
+        _ => None,
+    }?;
+
+    let segment_arguments = match &last_segment.arguments {
+        PathArguments::AngleBracketed(generic_arguments) => Some(generic_arguments),
+        _ => None,
+    }?;
+
+    let type_args: Vec<_> = segment_arguments
+        .args
+        .iter()
+        .filter_map(|arg| match arg {
+            GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect();
+    if type_args.is_empty() {
+        return None;
+    }
+
+    Some(type_args)
+}

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Fields, ItemEnum, ItemStruct, Result, Variant};
+use syn::{Fields, Generics, ItemEnum, ItemStruct, Result, Variant};
 
 use crate::attr::{EnumAttr, FieldAttr, Inflection, StructAttr};
 use crate::DerivedTS;
@@ -14,12 +14,17 @@ pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
     let StructAttr { rename_all, rename } = StructAttr::from_attrs(&s.attrs)?;
     let name = rename.unwrap_or_else(|| s.ident.to_string());
 
-    type_def(&name, &rename_all, &s.fields)
+    type_def(&name, &rename_all, &s.fields, &s.generics)
 }
 
-fn type_def(name: &str, rename_all: &Option<Inflection>, fields: &Fields) -> Result<DerivedTS> {
+fn type_def(
+    name: &str,
+    rename_all: &Option<Inflection>,
+    fields: &Fields,
+    generics: &Generics,
+) -> Result<DerivedTS> {
     match fields {
-        Fields::Named(named) => named::named(name, rename_all, &named),
+        Fields::Named(named) => named::named(name, rename_all, &named, generics),
         Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
             newtype::newtype(name, rename_all, &unnamed)
         }
@@ -95,7 +100,7 @@ fn format_variant(
         _ => {}
     };
 
-    let derived_type = type_def(&name, &None, &variant.fields)?;
+    let derived_type = type_def(&name, &None, &variant.fields, &Generics::default())?;
     let inline_type = derived_type.inline;
     let derived_dependencies = derived_type.dependencies;
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    Field, FieldsNamed, GenericArgument, GenericParam, Generics, Ident, PathArguments, Result, Type,
+    Field, FieldsNamed, GenericArgument, GenericParam, Generics, PathArguments, Result, Type,
 };
 
 use crate::attr::{FieldAttr, Inflection};
@@ -151,13 +151,7 @@ fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
     }?;
 
     let segment_arguments = match &last_segment.arguments {
-        PathArguments::AngleBracketed(generic_arguments) => {
-            if has_specialized_impl(&last_segment.ident) {
-                None
-            } else {
-                Some(generic_arguments)
-            }
-        }
+        PathArguments::AngleBracketed(generic_arguments) => Some(generic_arguments),
         _ => None,
     }?;
 
@@ -217,14 +211,4 @@ fn format_type(ty: &Type, dependencies: &mut Vec<TokenStream>, generics: &Generi
             quote!(<#ty as ts_rs::TS>::name_with_type_args(#args))
         }
     }
-}
-
-fn has_specialized_impl(ident: &Ident) -> bool {
-    ident == "Arc"
-        || ident == "Box"
-        || ident == "Cell"
-        || ident == "Cow"
-        || ident == "Option"
-        || ident == "Rc"
-        || ident == "RefCell"
 }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,8 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    Field, FieldsNamed, GenericArgument, GenericParam, Generics, Ident, Path, PathArguments,
-    PathSegment, Result, Type,
+    Field, FieldsNamed, GenericArgument, GenericParam, Generics, Ident, PathArguments, Result, Type,
 };
 
 use crate::attr::{FieldAttr, Inflection};
@@ -127,10 +126,7 @@ fn format_field(
                         ty,
                         Type::Path(type_path)
                             if type_path.qself.is_none()
-                            && type_path.path == Path::from(PathSegment {
-                                ident: type_param.ident.clone(),
-                                arguments: PathArguments::None,
-                            })
+                            && type_path.path.is_ident(&type_param.ident)
                     )
                 })
                 .map(|type_param| type_param.ident.to_string())

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -5,6 +5,7 @@ use syn::{
 };
 
 use crate::attr::{FieldAttr, Inflection};
+use crate::types::generics::format_type;
 use crate::DerivedTS;
 
 pub(crate) fn named(
@@ -141,74 +142,5 @@ fn extract_option_argument(ty: &Type) -> Result<&Type> {
             }
         }
         _ => syn_err!("`optional` can only be used on an Option<T> type"),
-    }
-}
-
-fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
-    let last_segment = match ty {
-        Type::Path(type_path) => type_path.path.segments.last(),
-        _ => None,
-    }?;
-
-    let segment_arguments = match &last_segment.arguments {
-        PathArguments::AngleBracketed(generic_arguments) => Some(generic_arguments),
-        _ => None,
-    }?;
-
-    let type_args: Vec<_> = segment_arguments
-        .args
-        .iter()
-        .filter_map(|arg| match arg {
-            GenericArgument::Type(ty) => Some(ty),
-            _ => None,
-        })
-        .collect();
-    if type_args.is_empty() {
-        return None;
-    }
-
-    Some(type_args)
-}
-
-fn format_type(ty: &Type, dependencies: &mut Vec<TokenStream>, generics: &Generics) -> TokenStream {
-    // If the type matches one of the generic parameters, just pass the identifier:
-    if let Some(generic_ident) = generics
-        .params
-        .iter()
-        .filter_map(|param| match param {
-            GenericParam::Type(type_param) => Some(type_param),
-            _ => None,
-        })
-        .find(|type_param| {
-            matches!(
-                ty,
-                Type::Path(type_path)
-                    if type_path.qself.is_none()
-                    && type_path.path.is_ident(&type_param.ident)
-            )
-        })
-        .map(|type_param| type_param.ident.to_string())
-    {
-        return quote!(#generic_ident.to_owned());
-    }
-
-    dependencies.push(quote! {
-        if <#ty as ts_rs::TS>::transparent() {
-            dependencies.append(&mut <#ty as ts_rs::TS>::dependencies());
-        } else {
-            dependencies.push((std::any::TypeId::of::<#ty>(), <#ty as ts_rs::TS>::name()));
-        }
-    });
-
-    match extract_type_args(ty) {
-        None => quote!(<#ty as ts_rs::TS>::name()),
-        Some(type_args) => {
-            let args = type_args
-                .iter()
-                .map(|ty| format_type(ty, dependencies, generics))
-                .collect::<Vec<_>>();
-            let args = quote!(vec![#(#args),*]);
-            quote!(<#ty as ts_rs::TS>::name_with_type_args(#args))
-        }
     }
 }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -112,60 +112,11 @@ fn format_field(
         });
     }
 
-    let formatted_ty =
-        type_override.map(|t| quote!(#t)).unwrap_or_else(|| {
-            if let Some(generic_ident) = generics
-                .params
-                .iter()
-                .filter_map(|param| match param {
-                    GenericParam::Type(type_param) => Some(type_param),
-                    _ => None,
-                })
-                .find(|type_param| {
-                    matches!(
-                        ty,
-                        Type::Path(type_path)
-                            if type_path.qself.is_none()
-                            && type_path.path.is_ident(&type_param.ident)
-                    )
-                })
-                .map(|type_param| type_param.ident.to_string())
-            {
-                quote!(#generic_ident)
-            } else if let Some((name, generic_args)) =
-                match ty {
-                    Type::Path(type_path) => type_path.path.segments.last().and_then(|segment| {
-                        match &segment.arguments {
-                            PathArguments::AngleBracketed(generic_arguments) => {
-                                if has_specialized_impl(&segment.ident) {
-                                    None
-                                } else {
-                                    Some((segment.ident.to_string(), &generic_arguments.args))
-                                }
-                            }
-                            _ => None,
-                        }
-                    }),
-                    _ => None,
-                }
-            {
-                let args = generic_args
-                    .iter()
-                    .filter_map(|arg| match arg {
-                        GenericArgument::Type(Type::Path(type_path)) => {
-                            let path = &type_path.path;
-                            Some(quote!(<#path as ts_rs::TS>::name()))
-                        }
-                        _ => None,
-                    })
-                    .collect::<TokenStream>();
-                quote!(format!("{}<{}>", #name, #args))
-            } else {
-                match inline {
-                    true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
-                    false => quote!(<#ty as ts_rs::TS>::name()),
-                }
-            }
+    let formatted_ty = type_override
+        .map(|t| quote!(#t))
+        .unwrap_or_else(|| match inline {
+            true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
+            false => format_type(ty, generics),
         });
     let name = match (rename, rename_all) {
         (Some(rn), _) => rn,
@@ -203,17 +154,79 @@ fn extract_option_argument(ty: &Type) -> Result<&Type> {
     }
 }
 
+fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
+    let last_segment = match ty {
+        Type::Path(type_path) => type_path.path.segments.last(),
+        _ => None,
+    }?;
+
+    let segment_arguments = match &last_segment.arguments {
+        PathArguments::AngleBracketed(generic_arguments) => {
+            if has_specialized_impl(&last_segment.ident) {
+                None
+            } else {
+                Some(generic_arguments)
+            }
+        }
+        _ => None,
+    }?;
+
+    let type_args: Vec<_> = segment_arguments
+        .args
+        .iter()
+        .filter_map(|arg| match arg {
+            GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .collect();
+    if type_args.is_empty() {
+        return None;
+    }
+
+    Some(type_args)
+}
+
+fn format_type(ty: &Type, generics: &Generics) -> TokenStream {
+    // If the type matches one of the generic parameters, just pass the identifier:
+    if let Some(generic_ident) = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            GenericParam::Type(type_param) => Some(type_param),
+            _ => None,
+        })
+        .find(|type_param| {
+            matches!(
+                ty,
+                Type::Path(type_path)
+                    if type_path.qself.is_none()
+                    && type_path.path.is_ident(&type_param.ident)
+            )
+        })
+        .map(|type_param| type_param.ident.to_string())
+    {
+        return quote!(#generic_ident.to_owned());
+    }
+
+    match extract_type_args(ty) {
+        None => quote!(<#ty as ts_rs::TS>::name()),
+        Some(type_args) => {
+            let args = type_args
+                .iter()
+                .map(|ty| format_type(ty, generics))
+                .collect::<Vec<_>>();
+            let args = quote!(vec![#(#args),*]);
+            quote!(<#ty as ts_rs::TS>::name_with_type_args(#args))
+        }
+    }
+}
+
 fn has_specialized_impl(ident: &Ident) -> bool {
     ident == "Arc"
         || ident == "Box"
-        || ident == "BTreeMap"
-        || ident == "BTreeSet"
         || ident == "Cell"
         || ident == "Cow"
-        || ident == "HashMap"
-        || ident == "HashSet"
         || ident == "Option"
         || ident == "Rc"
         || ident == "RefCell"
-        || ident == "Vec"
 }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,6 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Field, FieldsNamed, GenericArgument, PathArguments, Result, Type};
+use syn::{
+    Field, FieldsNamed, GenericArgument, GenericParam, Generics, Ident, Path, PathArguments,
+    PathSegment, Result, Type,
+};
 
 use crate::attr::{FieldAttr, Inflection};
 use crate::DerivedTS;
@@ -9,14 +12,35 @@ pub(crate) fn named(
     name: &str,
     rename_all: &Option<Inflection>,
     fields: &FieldsNamed,
+    generics: &Generics,
 ) -> Result<DerivedTS> {
     let mut formatted_fields = vec![];
     let mut dependencies = vec![];
     for field in &fields.named {
-        format_field(&mut formatted_fields, &mut dependencies, field, &rename_all)?;
+        format_field(
+            &mut formatted_fields,
+            &mut dependencies,
+            field,
+            &rename_all,
+            generics,
+        )?;
     }
 
     let fields = quote!(vec![#(#formatted_fields),*].join("\n"));
+    let generic_args = match &generics.params {
+        params if !params.is_empty() => {
+            let expanded_params = params
+                .iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            quote!(format!("<{}>", #expanded_params))
+        }
+        _ => quote!("".to_owned()),
+    };
 
     Ok(DerivedTS {
         inline: quote! {
@@ -26,7 +50,7 @@ pub(crate) fn named(
                 " ".repeat(indent * 4)
             )
         },
-        decl: quote!(format!("interface {} {}", #name, Self::inline(0))),
+        decl: quote!(format!("interface {}{} {}", #name, #generic_args, Self::inline(0))),
         inline_flattened: Some(fields),
         name: name.to_owned(),
         dependencies: quote! {
@@ -43,6 +67,7 @@ fn format_field(
     dependencies: &mut Vec<TokenStream>,
     field: &Field,
     rename_all: &Option<Inflection>,
+    generics: &Generics,
 ) -> Result<()> {
     let FieldAttr {
         type_override,
@@ -88,11 +113,63 @@ fn format_field(
         });
     }
 
-    let formatted_ty = type_override
-        .map(|t| quote!(#t))
-        .unwrap_or_else(|| match inline {
-            true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
-            false => quote!(<#ty as ts_rs::TS>::name()),
+    let formatted_ty =
+        type_override.map(|t| quote!(#t)).unwrap_or_else(|| {
+            if let Some(generic_ident) = generics
+                .params
+                .iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(type_param) => Some(type_param),
+                    _ => None,
+                })
+                .find(|type_param| {
+                    matches!(
+                        ty,
+                        Type::Path(type_path)
+                            if type_path.qself.is_none()
+                            && type_path.path == Path::from(PathSegment {
+                                ident: type_param.ident.clone(),
+                                arguments: PathArguments::None,
+                            })
+                    )
+                })
+                .map(|type_param| type_param.ident.to_string())
+            {
+                quote!(#generic_ident)
+            } else if let Some((name, generic_args)) =
+                match ty {
+                    Type::Path(type_path) => type_path.path.segments.last().and_then(|segment| {
+                        match &segment.arguments {
+                            PathArguments::AngleBracketed(generic_arguments) => {
+                                if has_specialized_impl(&segment.ident) {
+                                    None
+                                } else {
+                                    Some((segment.ident.to_string(), &generic_arguments.args))
+                                }
+                            }
+                            _ => None,
+                        }
+                    }),
+                    _ => None,
+                }
+            {
+                let args = generic_args
+                    .iter()
+                    .filter_map(|arg| match arg {
+                        GenericArgument::Type(Type::Path(type_path)) => {
+                            let path = &type_path.path;
+                            Some(quote!(<#path as ts_rs::TS>::name()))
+                        }
+                        _ => None,
+                    })
+                    .collect::<TokenStream>();
+                quote!(format!("{}<{}>", #name, #args))
+            } else {
+                match inline {
+                    true => quote!(<#ty as ts_rs::TS>::inline(indent + 1)),
+                    false => quote!(<#ty as ts_rs::TS>::name()),
+                }
+            }
         });
     let name = match (rename, rename_all) {
         (Some(rn), _) => rn,
@@ -128,4 +205,19 @@ fn extract_option_argument(ty: &Type) -> Result<&Type> {
         }
         _ => syn_err!("`optional` can only be used on an Option<T> type"),
     }
+}
+
+fn has_specialized_impl(ident: &Ident) -> bool {
+    ident == "Arc"
+        || ident == "Box"
+        || ident == "BTreeMap"
+        || ident == "BTreeSet"
+        || ident == "Cell"
+        || ident == "Cow"
+        || ident == "HashMap"
+        || ident == "HashSet"
+        || ident == "Option"
+        || ident == "Rc"
+        || ident == "RefCell"
+        || ident == "Vec"
 }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -117,6 +117,11 @@ pub trait TS: 'static {
     /// Name of this type in TypeScript.
     fn name() -> String;
 
+    /// Name of this type in TypeScript, with type arguments.
+    fn name_with_type_args(args: Vec<String>) -> String {
+        format!("{}<{}>", Self::name(), args.join(", "))
+    }
+
     /// Formats this types definition in TypeScript, e.g `{ user_id: number }`.
     /// This function will panic if the type cannot be inlined.
     fn inline(#[allow(unused_variables)] indent: usize) -> String {
@@ -265,11 +270,11 @@ impl<T: TS> TS for Option<T> {
 
 impl<T: TS> TS for Vec<T> {
     fn name() -> String {
-        format!("{}[]", T::name())
+        "Array".to_owned()
     }
 
     fn inline(indent: usize) -> String {
-        format!("{}[]", T::inline(indent))
+        format!("Array<{}>", T::inline(indent))
     }
 
     fn dependencies() -> Vec<(TypeId, String)> {
@@ -283,11 +288,11 @@ impl<T: TS> TS for Vec<T> {
 
 impl<T: TS> TS for HashSet<T> {
     fn name() -> String {
-        format!("{}[]", T::name())
+        "Array".to_owned()
     }
 
     fn inline(indent: usize) -> String {
-        format!("{}[]", T::inline(indent))
+        format!("Array<{}>", T::inline(indent))
     }
 
     fn dependencies() -> Vec<(TypeId, String)> {
@@ -301,11 +306,11 @@ impl<T: TS> TS for HashSet<T> {
 
 impl<T: TS> TS for BTreeSet<T> {
     fn name() -> String {
-        format!("{}[]", T::name())
+        "Array".to_owned()
     }
 
     fn inline(indent: usize) -> String {
-        format!("{}[]", T::inline(indent))
+        format!("Array<{}>", T::inline(indent))
     }
 
     fn dependencies() -> Vec<(TypeId, String)> {
@@ -319,11 +324,11 @@ impl<T: TS> TS for BTreeSet<T> {
 
 impl<K: TS, V: TS> TS for HashMap<K, V> {
     fn name() -> String {
-        format!("{{ [key: {}]: {} }}", K::name(), V::name())
+        "Record".to_owned()
     }
 
     fn inline(indent: usize) -> String {
-        format!("{{ [key: {}]: {} }}", K::inline(indent), V::inline(indent))
+        format!("Record<{}, {}>", K::inline(indent), V::inline(indent))
     }
 
     fn dependencies() -> Vec<(TypeId, String)> {
@@ -340,11 +345,11 @@ impl<K: TS, V: TS> TS for HashMap<K, V> {
 
 impl<K: TS, V: TS> TS for BTreeMap<K, V> {
     fn name() -> String {
-        format!("{{ [key: {}]: {} }}", K::name(), V::name())
+        "Record".to_owned()
     }
 
     fn inline(indent: usize) -> String {
-        format!("{{ [key: {}]: {} }}", K::inline(indent), V::inline(indent))
+        format!("Record<{}, {}>", K::inline(indent), V::inline(indent))
     }
 
     fn dependencies() -> Vec<(TypeId, String)> {

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -219,6 +219,9 @@ macro_rules! impl_proxy {
             fn name() -> String {
                 T::name()
             }
+            fn name_with_type_args(_: Vec<String>) -> String {
+                T::name()
+            }
             fn inline(indent: usize) -> String {
                 T::inline(indent)
             }
@@ -229,7 +232,7 @@ macro_rules! impl_proxy {
                 T::dependencies()
             }
             fn transparent() -> bool {
-                true
+                T::transparent()
             }
         }
     };
@@ -253,6 +256,10 @@ impl_proxy!(impl<T: TS> TS for std::cell::RefCell<T>);
 impl<T: TS> TS for Option<T> {
     fn name() -> String {
         format!("{} | null", T::name())
+    }
+
+    fn name_with_type_args(_: Vec<String>) -> String {
+        Self::name()
     }
 
     fn inline(indent: usize) -> String {

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -219,8 +219,12 @@ macro_rules! impl_proxy {
             fn name() -> String {
                 T::name()
             }
-            fn name_with_type_args(_: Vec<String>) -> String {
-                T::name()
+            fn name_with_type_args(args: Vec<String>) -> String {
+                if args.len() == 1 {
+                    args[0].clone()
+                } else {
+                    format!("[{}]", args.join(", "))
+                }
             }
             fn inline(indent: usize) -> String {
                 T::inline(indent)

--- a/ts-rs/tests/generic_struct.rs
+++ b/ts-rs/tests/generic_struct.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use ts_rs::TS;
 
 #[derive(TS)]
@@ -8,11 +9,14 @@ where
     T: TS,
 {
     value: T,
+    values: Vec<T>,
 }
 
 #[derive(TS)]
 struct Container {
     foo: Generic<u32>,
+    bar: Vec<Generic<u32>>,
+    baz: HashMap<String, Generic<String>>,
 }
 
 #[test]
@@ -22,6 +26,7 @@ fn test() {
         "\
 interface Generic<T> {
     value: T,
+    values: Array<T>,
 }"
     );
 
@@ -30,6 +35,8 @@ interface Generic<T> {
         "\
 interface Container {
     foo: Generic<number>,
+    bar: Array<Generic<number>>,
+    baz: Record<string, Generic<string>>,
 }"
     );
 }

--- a/ts-rs/tests/generic_struct.rs
+++ b/ts-rs/tests/generic_struct.rs
@@ -1,0 +1,35 @@
+#![allow(dead_code)]
+
+use ts_rs::TS;
+
+#[derive(TS)]
+struct Generic<T>
+where
+    T: TS,
+{
+    value: T,
+}
+
+#[derive(TS)]
+struct Container {
+    foo: Generic<u32>,
+}
+
+#[test]
+fn test() {
+    assert_eq!(
+        Generic::<()>::decl(),
+        "\
+interface Generic<T> {
+    value: T,
+}"
+    );
+
+    assert_eq!(
+        Container::decl(),
+        "\
+interface Container {
+    foo: Generic<number>,
+}"
+    );
+}

--- a/ts-rs/tests/simple.rs
+++ b/ts-rs/tests/simple.rs
@@ -20,7 +20,7 @@ fn test_def() {
     a: number,
     b: string,
     c: [number, string, number],
-    d: string[],
+    d: Array<string>,
     e: string | null,
 }"
     )
@@ -35,7 +35,7 @@ fn test_indented() {
         a: number,
         b: string,
         c: [number, string, number],
-        d: string[],
+        d: Array<string>,
         e: string | null,
     }"
     )

--- a/ts-rs/tests/union_serde.rs
+++ b/ts-rs/tests/union_serde.rs
@@ -31,16 +31,16 @@ enum Untagged {
 fn test_serde_enum() {
     assert_eq!(
         SimpleEnum::decl(),
-        r#"type SimpleEnum = {kind: "A"} | {kind: "B"};"#
+        r#"type SimpleEnum = { kind: "A" } | { kind: "B" };"#
     );
     assert_eq!(
         ComplexEnum::decl(),
-        r#"type ComplexEnum = {kind: "A"} | {kind: "B", data: {
+        r#"type ComplexEnum = { kind: "A" } | { kind: "B", data: {
     foo: string,
     bar: number,
-}} | {kind: "W", data: SimpleEnum} | {kind: "F", data: {
+} } | { kind: "W", data: SimpleEnum } | { kind: "F", data: {
     nested: SimpleEnum,
-}} | {kind: "T", data: [number, SimpleEnum]};"#
+} } | { kind: "T", data: [number, SimpleEnum] };"#
     );
 
     assert_eq!(

--- a/ts-rs/tests/union_serde.rs
+++ b/ts-rs/tests/union_serde.rs
@@ -31,11 +31,11 @@ enum Untagged {
 fn test_serde_enum() {
     assert_eq!(
         SimpleEnum::decl(),
-        r#"type SimpleEnum = {kind: "A", d: null} | {kind: "B", d: null};"#
+        r#"type SimpleEnum = {kind: "A"} | {kind: "B"};"#
     );
     assert_eq!(
         ComplexEnum::decl(),
-        r#"type ComplexEnum = {kind: "A", data: null} | {kind: "B", data: {
+        r#"type ComplexEnum = {kind: "A"} | {kind: "B", data: {
     foo: string,
     bar: number,
 }} | {kind: "W", data: SimpleEnum} | {kind: "F", data: {

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -31,19 +31,11 @@ enum EnumWithInternalTag2 {
 fn test_enums_with_internal_tags() {
     assert_eq!(
         EnumWithInternalTag::decl(),
-        r#"type EnumWithInternalTag = {
-    type: "A",
-    foo: string,
-} | {
-    type: "B",
-    bar: number,
-};"#
+        r#"type EnumWithInternalTag = { type: "A",     foo: string, } | { type: "B",     bar: number, };"#
     );
 
     assert_eq!(
         EnumWithInternalTag2::decl(),
-        r#"type EnumWithInternalTag2 = 
-    { type: "A" } & InnerA | 
-    { type: "B" } & InnerB;"#
+        r#"type EnumWithInternalTag2 = { type: "A" } & InnerA | { type: "B" } & InnerB;"#
     );
 }


### PR DESCRIPTION
This is the latest PR for applying generics support. It fixes #14 and #22 and supersedes #18.

Generics are now supported, which includes generic structs such as `MyStruct<T>` and generic arguments to existing containers such as `Vec<MyItem>`.

It also contains a few minor fixes as described in #22.