### PR TITLE
Handle unit structs defined as Unit{} and Unit()

### DIFF
--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -29,11 +29,15 @@ fn type_def(
     generics: &Generics,
 ) -> Result<DerivedTS> {
     match fields {
-        Fields::Named(named) => named::named(name, rename_all, named, generics),
-        Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
-            newtype::newtype(name, rename_all, unnamed)
-        }
-        Fields::Unnamed(unnamed) => tuple::tuple(name, rename_all, unnamed),
+        Fields::Named(named) => match named.named.len() {
+            0 => unit::unit(name, rename_all),
+            _ => named::named(name, rename_all, named, generics),
+        },
+        Fields::Unnamed(unnamed) => match unnamed.unnamed.len() {
+            0 => unit::unit(name, rename_all),
+            1 => newtype::newtype(name, rename_all, unnamed),
+            _ => tuple::tuple(name, rename_all, unnamed),
+        },
         Fields::Unit => unit::unit(name, rename_all),
     }
 }

--- a/ts-rs/tests/unit.rs
+++ b/ts-rs/tests/unit.rs
@@ -3,7 +3,15 @@ use ts_rs::TS;
 #[derive(TS)]
 struct Unit;
 
+#[derive(TS)]
+struct Unit2{}
+
+#[derive(TS)]
+struct Unit3();
+
 #[test]
 fn test() {
-    assert_eq!("type Unit = null;", Unit::decl())
+    assert_eq!("type Unit = null;", Unit::decl());
+    assert_eq!("type Unit2 = null;", Unit2::decl());
+    assert_eq!("type Unit3 = null;", Unit3::decl());
 }


### PR DESCRIPTION
Haven't actually checked if serde handles all cases the same, but what else could it do?