### PR TITLE
[WIP] Next

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+If you are unsure what to work on or want to discuss your idea, feel free to open an issue.  
+
+### Documentation
+After implementing a new feature, please document it in the doc comment on `TS` in `ts_rs/lib.rs`.  
+`README.md` is generated from the module doc comment in `ts_rs/lib.rs`. If you added/updated documentation there, run
+`cargo readme > ../README.md` from the `ts_rs/` directory.  
+You can install `cargo readme` by running `cargo install cargo-readme`.
+
+
+### Tests
+Please remember to write tests - If you are fixing a bug, write a test first to reproduce it.
+
+### Building
+There is nothing special going on here - just run `cargo build`.  
+To run the test suite, just run `cargo test` in the root directory.  
+
+### Formatting
+To ensure proper formatting, please run `cargo +nightly fmt`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["macros", "ts-rs", "example"]
+members = ["config", "macros", "ts-rs", "example"]

--- a/README.md
+++ b/README.md
@@ -1,75 +1,73 @@
+# ts-rs
+
 <h1 align="center" style="padding-top: 0; margin-top: 0;">
-    <img width="150px" src="https://raw.githubusercontent.com/Aleph-Alpha/ts-rs/main/logo.png" alt="logo">
-    <br/>
-    ts-rs
+<img width="150px" src="https://raw.githubusercontent.com/Aleph-Alpha/ts-rs/main/logo.png" alt="logo">
+<br/>
+ts-rs
 </h1>
 <p align="center">
-   generate typescript interface/type declarations from rust types
+generate typescript interface/type declarations from rust types
 </p>
 
 <div align="center">
-  <!-- Github Actions -->
-  <img src="https://img.shields.io/github/workflow/status/Aleph-Alpha/ts-rs/Test?style=flat-square" alt="actions status" />
-  <a href="https://crates.io/crates/ts-rs">
-    <img src="https://img.shields.io/crates/v/ts-rs.svg?style=flat-square"
-    alt="Crates.io version" />
-  </a>
-  <a href="https://docs.rs/ts-rs">
-    <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
-      alt="docs.rs docs" />
-  </a>
-  <a href="https://crates.io/crates/ts-rs">
-    <img src="https://img.shields.io/crates/d/ts-rs.svg?style=flat-square"
-      alt="Download" />
-  </a>
+<!-- Github Actions -->
+<img src="https://img.shields.io/github/workflow/status/Aleph-Alpha/ts-rs/Test?style=flat-square" alt="actions status" />
+<a href="https://crates.io/crates/ts-rs">
+<img src="https://img.shields.io/crates/v/ts-rs.svg?style=flat-square"
+alt="Crates.io version" />
+</a>
+<a href="https://docs.rs/ts-rs">
+<img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
+alt="docs.rs docs" />
+</a>
+<a href="https://crates.io/crates/ts-rs">
+<img src="https://img.shields.io/crates/d/ts-rs.svg?style=flat-square"
+alt="Download" />
+</a>
 </div>
 
-## why?
-When building a web application in rust, data structures have to be shared between backend and frontend.  
+### why?
+When building a web application in rust, data structures have to be shared between backend and frontend.
 Using this library, you can easily generate TypeScript bindings to your rust structs & enums, so that you can keep your
 types in one place.
 
 ts-rs might also come in handy when working with webassembly.
 
-## how?
-ts-rs exposes a single trait, `TS`. Using a derive macro, you can implement this interface for your types.  
-Then, you can use this trait to obtain the TypeScript bindings.  
-We recommend doing this in your tests. [see the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs)
+### how?
+ts-rs exposes a single trait, `TS`. Using a derive macro, you can implement this interface for your types.
+Then, you can use this trait to obtain the TypeScript bindings.
+We recommend doing this in your tests. [See the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs) and [the docs](https://docs.rs/ts-rs/latest/ts_rs/).
 
-## get started
+### get started
 ```toml
 [dependencies]
-ts-rs = "5.1"
+ts-rs = "6.0"
 ```
 
 ```rust
 use ts_rs::{TS, export};
 
 #[derive(TS)]
+#[ts(export)]
 struct User {
     user_id: i32,
     first_name: String,
     last_name: String,
 }
-
-export! {
-    User => "bindings.ts"
-}
 ```
-When running `cargo test`, the TypeScript bindings will be exported to the file `bindings.ts`.
+When running `cargo test`, the TypeScript bindings will be exported to the file `bindings/User.ts`.
 
-## [example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs)
-
-## features
+### features
 - generate interface declarations from rust structs
 - generate union declarations from rust enums
 - inline types
 - flatten structs/interfaces
 - generate necessary imports when exporting to multiple files
-- `export ..` and `declare ..`
+- serde compatibility
+- generic types
 
-## serde compatability
-With `serde-compat`, serde attributes can be parsed for enums and structs.  
+### serde compatability
+With the `serde-compat` feature (enabled by default), serde attributes can be parsed for enums and structs.
 Supported serde attributes:
 - `rename`
 - `rename-all`
@@ -83,10 +81,18 @@ Supported serde attributes:
 - `flatten`
 - `default`
 
-## todo
+When ts-rs encounters an unsupported serde attribute, a warning is emitted.
+
+### contributing
+Contributions are always welcome!
+Feel free to open an issue, discuss using GitHub discussions or open a PR.
+
+### todo
 - [x] serde compatibility layer
 - [x] documentation
 - [x] use typescript types across files
 - [x] more enum representations
-- [x] generics  
+- [x] generics
 - [ ] don't require `'static`
+
+License: MIT

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ When ts-rs encounters an unsupported serde attribute, a warning is emitted.
 ### contributing
 Contributions are always welcome!
 Feel free to open an issue, discuss using GitHub discussions or open a PR.
+[see CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
 
 ### todo
 - [x] serde compatibility layer

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ alt="Download" />
 
 ### why?
 When building a web application in rust, data structures have to be shared between backend and frontend.
-Using this library, you can easily generate TypeScript bindings to your rust structs & enums, so that you can keep your
+Using this library, you can easily generate TypeScript bindings to your rust structs & enums so that you can keep your
 types in one place.
 
 ts-rs might also come in handy when working with webassembly.
@@ -36,7 +36,8 @@ ts-rs might also come in handy when working with webassembly.
 ### how?
 ts-rs exposes a single trait, `TS`. Using a derive macro, you can implement this interface for your types.
 Then, you can use this trait to obtain the TypeScript bindings.
-We recommend doing this in your tests. [See the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs) and [the docs](https://docs.rs/ts-rs/latest/ts_rs/).
+We recommend doing this in your tests.
+[See the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs) and [the docs](https://docs.rs/ts-rs/latest/ts_rs/).
 
 ### get started
 ```toml
@@ -45,7 +46,7 @@ ts-rs = "6.0"
 ```
 
 ```rust
-use ts_rs::{TS, export};
+use ts_rs::TS;
 
 #[derive(TS)]
 #[ts(export)]
@@ -65,6 +66,20 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 - generate necessary imports when exporting to multiple files
 - serde compatibility
 - generic types
+
+### cargo features
+- `serde-compat` (default)
+  Enable serde compatibility. See below for more info.
+- `chrono-impl`
+  Implement `TS` for types from chrono
+- `bigdecimal-impl`
+  Implement `TS` for types from bigdecimal
+- `uuid-impl`
+  Implement `TS` for types from uuid
+- `bytes-impl`
+  Implement `TS` for types from bytes
+
+If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 
 ### serde compatability
 With the `serde-compat` feature (enabled by default), serde attributes can be parsed for enums and structs.
@@ -86,7 +101,7 @@ When ts-rs encounters an unsupported serde attribute, a warning is emitted.
 ### contributing
 Contributions are always welcome!
 Feel free to open an issue, discuss using GitHub discussions or open a PR.
-[see CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
+[See CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
 
 ### todo
 - [x] serde compatibility layer

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ts-rs-config"
+version = "5.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+toml = "0.5"
+anyhow = "1"
+once_cell = "1.8"

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,5 @@
+# ts-rs-config
+This crate contains the config for future ts-rs versions.  
+Currently, it's not really possible no use the config within the proc macro due to issues regarding incremental compilation.  
+A workaround would be to have `include_str!("ts.toml")` everywhere, but I don't think we should do that.  
+Instead, let's wait for https://github.com/rust-lang/rust/issues/73921

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -1,0 +1,62 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Result;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {
+    ambient_declarations: bool,
+    out_dir: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ambient_declarations: false,
+            out_dir: "typescript".to_owned(),
+        }
+    }
+}
+
+static CONFIG_INSTANCE: OnceCell<Arc<Config>> = OnceCell::new();
+
+impl Config {
+    const FILE_NAME: &'static str = "ts.toml";
+
+    pub fn get() -> Result<Arc<Self>> {
+        match CONFIG_INSTANCE.get() {
+            None => {
+                let cfg = Arc::new(Self::load()?);
+                CONFIG_INSTANCE.set(cfg.clone()).ok();
+                Ok(cfg)
+            }
+            Some(cfg) => Ok(cfg.clone()),
+        }
+    }
+
+    fn load() -> Result<Self> {
+        let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR")?);
+        let config = Self::try_load_from_dir(&manifest_dir)?.unwrap_or_default();
+        Ok(config)
+    }
+
+    fn try_load_from_dir(dir: &Path) -> Result<Option<Self>> {
+        let path = {
+            let mut path = PathBuf::from(dir);
+            path.push(Self::FILE_NAME);
+            path
+        };
+        match path.is_file() {
+            true => {
+                let content = std::fs::read_to_string(path)?;
+                let parsed = toml::from_str::<Config>(&content)?;
+                Ok(Some(parsed))
+            }
+            false => Ok(None),
+        }
+    }
+}

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -4,12 +4,12 @@ use std::{collections::BTreeSet, rc::Rc};
 
 use chrono::NaiveDateTime;
 use serde::Serialize;
-use ts_rs::{export, TS};
+use ts_rs::TS;
 use uuid::Uuid;
 
 #[derive(Serialize, TS)]
 #[ts(rename_all = "lowercase")]
-#[ts(export)]
+#[ts(export, export_to = "bindings/UserRole.ts")]
 enum Role {
     User,
     #[ts(rename = "administrator")]
@@ -103,22 +103,4 @@ enum InlineComplexEnum {
 struct ComplexStruct {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub string_tree: Option<Rc<BTreeSet<String>>>,
-}
-
-// this will export [Role] to `role.ts` and [User] to `user.ts` when running `cargo test`.
-// `export!` will also take care of including imports in typescript files.
-export! {
-    Role => "role.ts",
-    User => "user.ts",
-    // any type can be used here in place of the generic, but it has to match the one used
-    // in other structs to generate the dependencies correctly:
-    Point<u64> => "point.ts",
-    Series => "series.ts",
-    Vehicle => "vehicle.ts",
-    ComplexEnum => "complex_enum.ts",
-    InlineComplexEnum => "inline_complex_enum.ts",
-    SimpleEnum => "simple_enum.ts",
-    ComplexStruct => "complex_struct.ts",
-    // this exports an ambient declaration (`declare interface`) instead of an `export interface`.
-    (declare) Gender => "gender.d.ts",
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 #[derive(Serialize, TS)]
 #[ts(rename_all = "lowercase")]
+#[ts(export)]
 enum Role {
     User,
     #[ts(rename = "administrator")]
@@ -18,6 +19,7 @@ enum Role {
 #[derive(Serialize, TS)]
 // when 'serde-compat' is enabled, ts-rs tries to use supported serde attributes.
 #[serde(rename_all = "UPPERCASE")]
+#[ts(export)]
 enum Gender {
     Male,
     Female,
@@ -25,6 +27,7 @@ enum Gender {
 }
 
 #[derive(Serialize, TS)]
+#[ts(export)]
 struct User {
     user_id: i32,
     first_name: String,
@@ -40,12 +43,14 @@ struct User {
 
 #[derive(Serialize, TS)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[ts(export)]
 enum Vehicle {
     Bicycle { color: String },
     Car { brand: String, color: String },
 }
 
 #[derive(Serialize, TS)]
+#[ts(export)]
 struct Point<T>
 where
     T: TS,
@@ -55,12 +60,14 @@ where
 }
 
 #[derive(Serialize, TS)]
+#[ts(export)]
 struct Series {
     points: Vec<Point<u64>>,
 }
 
 #[derive(Serialize, TS)]
 #[serde(tag = "kind", content = "d")]
+#[ts(export)]
 enum SimpleEnum {
     A,
     B,
@@ -68,6 +75,7 @@ enum SimpleEnum {
 
 #[derive(Serialize, TS)]
 #[serde(tag = "kind", content = "data")]
+#[ts(export)]
 enum ComplexEnum {
     A,
     B { foo: String, bar: f64 },
@@ -79,6 +87,7 @@ enum ComplexEnum {
 
 #[derive(Serialize, TS)]
 #[serde(tag = "kind")]
+#[ts(export)]
 enum InlineComplexEnum {
     A,
     B { foo: String, bar: f64 },
@@ -90,6 +99,7 @@ enum InlineComplexEnum {
 
 #[derive(Serialize, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export)]
 struct ComplexStruct {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub string_tree: Option<Rc<BTreeSet<String>>>,

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ts-rs-macros"
-version = "5.1.0"
+version = "6.0.0"
 authors = ["Moritz Bischof <moritz.bischof1@gmail.com>"]
 edition = "2021"
 description = "derive macro for ts-rs"

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -1,7 +1,7 @@
 use syn::{Attribute, Ident, Result};
 
 use crate::{
-    attr::{parse_assign_inflection, parse_assign_str, parse_opt_assign_str, Inflection},
+    attr::{parse_assign_inflection, parse_assign_str, Inflection},
     utils::parse_attrs,
 };
 
@@ -9,7 +9,8 @@ use crate::{
 pub struct EnumAttr {
     pub rename_all: Option<Inflection>,
     pub rename: Option<String>,
-    pub export: Option<Option<String>>,
+    pub export_to: Option<String>,
+    pub export: bool,
     tag: Option<String>,
     untagged: bool,
     content: Option<String>,
@@ -56,6 +57,7 @@ impl EnumAttr {
             tag,
             content,
             untagged,
+            export_to,
             export,
         }: EnumAttr,
     ) {
@@ -64,7 +66,8 @@ impl EnumAttr {
         self.tag = self.tag.take().or(tag);
         self.untagged = self.untagged || untagged;
         self.content = self.content.take().or(content);
-        self.export = self.export.take().or(export);
+        self.export = self.export || export;
+        self.export_to = self.export_to.take().or(export_to);
     }
 }
 
@@ -72,7 +75,8 @@ impl_parse! {
     EnumAttr(input, out) {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
-        "export" => out.export = Some(parse_opt_assign_str(input)?)
+        "export_to" => out.export_to = Some(parse_assign_str(input)?),
+        "export" => out.export = true
     }
 }
 

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -61,14 +61,6 @@ fn parse_assign_str(input: ParseStream) -> Result<String> {
     }
 }
 
-fn parse_opt_assign_str(input: ParseStream) -> Result<Option<String>> {
-    if input.is_empty() || !input.peek(Token![=]) {
-        Ok(None)
-    } else {
-        parse_assign_str(input).map(Some)
-    }
-}
-
 fn parse_assign_inflection(input: ParseStream) -> Result<Inflection> {
     parse_assign_str(input).and_then(Inflection::try_from)
 }

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -61,6 +61,14 @@ fn parse_assign_str(input: ParseStream) -> Result<String> {
     }
 }
 
+fn parse_opt_assign_str(input: ParseStream) -> Result<Option<String>> {
+    if input.is_empty() || !input.peek(Token![=]) {
+        Ok(None)
+    } else {
+        parse_assign_str(input).map(Some)
+    }
+}
+
 fn parse_assign_inflection(input: ParseStream) -> Result<Inflection> {
     parse_assign_str(input).and_then(Inflection::try_from)
 }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::parse_attrs,
 };
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StructAttr {
     pub rename_all: Option<Inflection>,
     pub rename: Option<String>,

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use syn::{Attribute, Ident, Result};
 
 use crate::{
-    attr::{parse_assign_str, parse_opt_assign_str, Inflection},
+    attr::{parse_assign_str, Inflection},
     utils::parse_attrs,
 };
 
@@ -11,7 +11,8 @@ use crate::{
 pub struct StructAttr {
     pub rename_all: Option<Inflection>,
     pub rename: Option<String>,
-    pub export: Option<Option<String>>,
+    pub export_to: Option<String>,
+    pub export: bool,
 }
 
 #[cfg(feature = "serde-compat")]
@@ -33,11 +34,13 @@ impl StructAttr {
             rename_all,
             rename,
             export,
+            export_to,
         }: StructAttr,
     ) {
         self.rename = self.rename.take().or(rename);
         self.rename_all = self.rename_all.take().or(rename_all);
-        self.export = self.export.take().or(export);
+        self.export_to = self.export_to.take().or(export_to);
+        self.export = self.export || export;
     }
 }
 
@@ -45,7 +48,8 @@ impl_parse! {
     StructAttr(input, out) {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
-        "export" => out.export = Some(parse_opt_assign_str(input)?)
+        "export" => out.export = true,
+        "export_to" => out.export_to = Some(parse_assign_str(input)?)
     }
 }
 

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use syn::{Attribute, Ident, Result};
 
 use crate::{
-    attr::{parse_assign_str, Inflection},
+    attr::{parse_assign_str, parse_opt_assign_str, Inflection},
     utils::parse_attrs,
 };
 
@@ -11,6 +11,7 @@ use crate::{
 pub struct StructAttr {
     pub rename_all: Option<Inflection>,
     pub rename: Option<String>,
+    pub export: Option<Option<String>>,
 }
 
 #[cfg(feature = "serde-compat")]
@@ -26,9 +27,17 @@ impl StructAttr {
         Ok(result)
     }
 
-    fn merge(&mut self, StructAttr { rename_all, rename }: StructAttr) {
+    fn merge(
+        &mut self,
+        StructAttr {
+            rename_all,
+            rename,
+            export,
+        }: StructAttr,
+    ) {
         self.rename = self.rename.take().or(rename);
         self.rename_all = self.rename_all.take().or(rename_all);
+        self.export = self.export.take().or(export);
     }
 }
 
@@ -36,6 +45,7 @@ impl_parse! {
     StructAttr(input, out) {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
+        "export" => out.export = Some(parse_opt_assign_str(input)?)
     }
 }
 

--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -18,9 +18,9 @@ impl Dependencies {
         self.0.push(quote! {
             if <#ty as ts_rs::TS>::transparent() {
               dependencies.append(&mut <#ty as ts_rs::TS>::dependencies());
-          } else {
-                dependencies.push((std::any::TypeId::of::<#ty>(), <#ty as ts_rs::TS>::name()));
-          }
+            } else {
+                dependencies.push(ts_rs::Dependency::from_ty::<#ty>());
+            }
         });
     }
 

--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -19,7 +19,9 @@ impl Dependencies {
             if <#ty as ts_rs::TS>::transparent() {
               dependencies.append(&mut <#ty as ts_rs::TS>::dependencies());
             } else {
-                dependencies.push(ts_rs::Dependency::from_ty::<#ty>());
+                if let Some(dep) = ts_rs::Dependency::from_ty::<#ty>() {
+                    dependencies.push(dep);
+                }
             }
         });
     }

--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -28,7 +28,7 @@ impl Dependencies {
 
     pub fn append(&mut self, other: Dependencies) {
         self.0.push(quote! {
-            dependencies.append(&mut #other)
+            dependencies.append(&mut #other);
         })
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(unused)]
 
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_quote, spanned::Spanned, GenericParam, Generics, Item, Result, WhereClause};
 
 use crate::deps::Dependencies;
@@ -19,10 +19,89 @@ struct DerivedTS {
     decl: TokenStream,
     inline_flattened: Option<TokenStream>,
     dependencies: Dependencies,
+    export: Option<Option<String>>,
 }
 
 impl DerivedTS {
+    fn generate_export_test(
+        &self,
+        rust_ty: &Ident,
+        generics: &Generics,
+        path: &str,
+    ) -> Option<TokenStream> {
+        let test_fn = format_ident!("export_bindings_{}", &self.name.to_lowercase());
+        let generic_params = generics
+            .params
+            .iter()
+            .filter(|param| matches!(param, GenericParam::Type(_)))
+            .map(|_| quote! { () });
+
+        let rust_ty = quote!(#rust_ty<#(#generic_params),*>);
+        let expanded = quote! {
+            #[cfg(test)]
+            #[test]
+            fn #test_fn() {
+                use std::{
+                    path::Path,
+                    fmt::Write,
+                    collections::BTreeSet,
+                    any::TypeId,
+                };
+                use ts_rs::export::{FmtCfg, fmt_ts};
+
+                let path = Path::new(#path);
+                let mut buffer = String::with_capacity(1024);
+
+                let deps = <#rust_ty as ts_rs::TS>::dependencies()
+                    .into_iter()
+                    .filter(|dep| dep.type_id != TypeId::of::<#rust_ty>())
+                    .collect::<BTreeSet<_>>();
+                for dep in deps {
+                    let exported_to = match dep.exported_to {
+                        None => continue,
+                        Some(to) => Path::new(to),
+                    };
+                    let rel_path = ts_rs::export::import_path(
+                        path,
+                        exported_to,
+                    );
+                    write!(&mut buffer, "import {{ {} }} from {:?};\n", &dep.ts_name, rel_path).unwrap();
+                }
+                buffer.push_str("\n");
+
+                buffer.push_str("export ");
+                buffer.push_str(
+                   &<#rust_ty as ts_rs::TS>::decl()
+                );
+
+                let buffer = fmt_ts(
+                    &path,
+                    &buffer,
+                    &FmtCfg::new().deno().build()
+                )
+                .expect("could not format output");
+
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent).expect("could not create directory");
+                }
+                std::fs::write(path, &buffer).expect("could not write bindings to file");
+            }
+        };
+        Some(expanded)
+    }
+
     fn into_impl(self, rust_ty: Ident, generics: Generics) -> TokenStream {
+        let export_to = self
+            .export
+            .clone()
+            .map(|export| export.unwrap_or_else(|| format!("bindings/{}.ts", &self.name)));
+        let export = export_to
+            .as_ref()
+            .map(|to| self.generate_export_test(&rust_ty, &generics, to));
+        let export_to = export_to
+            .map(|to| quote!(Some(#to)))
+            .unwrap_or_else(|| quote!(None));
+
         let DerivedTS {
             name,
             inline,
@@ -49,9 +128,10 @@ impl DerivedTS {
         } = generics;
 
         let where_clause = add_ts_trait_bound(&generics);
-
         quote! {
             impl #lt_token #params #gt_token ts_rs::TS for #rust_ty #lt_token #params #gt_token #where_clause {
+                const EXPORTED_TO: Option<&'static str> = #export_to;
+
                 fn decl() -> String {
                     #decl
                 }
@@ -62,13 +142,15 @@ impl DerivedTS {
                     #inline
                 }
                 #inline_flattened
-                fn dependencies() -> Vec<(std::any::TypeId, String)> {
+                fn dependencies() -> Vec<ts_rs::Dependency> {
                     #dependencies
                 }
                 fn transparent() -> bool {
                     false
                 }
             }
+
+            #export
         }
     }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -109,7 +109,7 @@ fn entry(input: proc_macro::TokenStream) -> Result<TokenStream> {
     let input = syn::parse::<Item>(input)?;
     let (ts, ident, generics) = match input {
         Item::Struct(s) => (types::struct_def(&s)?, s.ident, s.generics),
-        Item::Enum(e) => (types::r#enum(&e)?, e.ident, e.generics),
+        Item::Enum(e) => (types::enum_def(&e)?, e.ident, e.generics),
         _ => syn_err!(input.span(); "unsupported item"),
     };
 

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, format_ident};
+use quote::{format_ident, quote};
 use syn::{Fields, Generics, ItemEnum, Variant};
 
 use crate::{

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -38,6 +38,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
         dependencies,
         name,
         export: enum_attr.export,
+        export_to: enum_attr.export_to,
     })
 }
 
@@ -71,7 +72,7 @@ fn format_variant(
         (None, Some(rn)) => rn.apply(&variant.ident.to_string()),
     };
 
-    let variant_type = types::type_def(&name, &None, &variant.fields, generics, None)?;
+    let variant_type = types::type_def(&name, &None, &variant.fields, generics, false, None)?;
     let variant_dependencies = variant_type.dependencies;
     let inline_type = variant_type.inline;
 

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, format_ident};
 use syn::{Fields, Generics, ItemEnum, Variant};
 
 use crate::{
-    attr::{EnumAttr, FieldAttr, Tagged},
+    attr::{EnumAttr, FieldAttr, StructAttr, Tagged},
     deps::Dependencies,
     types,
     types::generics::{format_generics, format_type},
@@ -72,7 +72,13 @@ fn format_variant(
         (None, Some(rn)) => rn.apply(&variant.ident.to_string()),
     };
 
-    let variant_type = types::type_def(&name, &None, &variant.fields, generics, false, None)?;
+    let variant_type = types::type_def(
+        &StructAttr::default(),
+        // since we are generating the variant as a struct, it doesn't have a name
+        &format_ident!("_"),
+        &variant.fields,
+        generics,
+    )?;
     let variant_dependencies = variant_type.dependencies;
     let inline_type = variant_type.inline;
 

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -1,0 +1,116 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Fields, Generics, ItemEnum, Variant};
+
+use crate::{
+    attr::{EnumAttr, FieldAttr, Tagged},
+    deps::Dependencies,
+    types,
+    types::generics::{format_generics, format_type},
+    DerivedTS,
+};
+
+pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
+    let enum_attr: EnumAttr = EnumAttr::from_attrs(&s.attrs)?;
+
+    let name = match &enum_attr.rename {
+        Some(existing) => existing.clone(),
+        None => s.ident.to_string(),
+    };
+
+    let mut formatted_variants = vec![];
+    let mut dependencies = Dependencies::default();
+    for variant in &s.variants {
+        format_variant(
+            &mut formatted_variants,
+            &mut dependencies,
+            &enum_attr,
+            variant,
+            &s.generics,
+        )?;
+    }
+
+    let generic_args = format_generics(&s.generics).unwrap_or_default();
+    Ok(DerivedTS {
+        inline: quote!(vec![#(#formatted_variants),*].join(" | ")),
+        decl: quote!(format!("type {}{} = {};", #name, #generic_args, Self::inline())),
+        inline_flattened: None,
+        dependencies,
+        name,
+    })
+}
+
+fn format_variant(
+    formatted_variants: &mut Vec<TokenStream>,
+    dependencies: &mut Dependencies,
+    enum_attr: &EnumAttr,
+    variant: &Variant,
+    generics: &Generics,
+) -> syn::Result<()> {
+    let FieldAttr {
+        type_override,
+        rename,
+        inline,
+        skip,
+        optional,
+        flatten,
+    } = FieldAttr::from_attrs(&variant.attrs)?;
+
+    match (skip, &type_override, inline, optional, flatten) {
+        (true, ..) => return Ok(()),
+        (_, Some(_), ..) => syn_err!("`type_override` is not applicable to enum variants"),
+        (_, _, _, true, ..) => syn_err!("`optional` is not applicable to enum variants"),
+        (_, _, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
+        _ => {}
+    };
+
+    let name = match (rename, &enum_attr.rename_all) {
+        (Some(rn), _) => rn,
+        (None, None) => variant.ident.to_string(),
+        (None, Some(rn)) => rn.apply(&variant.ident.to_string()),
+    };
+
+    let variant_type = types::type_def(&name, &None, &variant.fields, generics)?;
+    let variant_dependencies = variant_type.dependencies;
+    let inline_type = variant_type.inline;
+
+    let formatted = match enum_attr.tagged()? {
+        Tagged::Untagged => quote!(#inline_type),
+        Tagged::Externally => match &variant.fields {
+            Fields::Unit => quote!(format!("\"{}\"", #name)),
+            _ => quote!(format!("{{ {}: {} }}", #name, #inline_type)),
+        },
+        Tagged::Adjacently { tag, content } => match &variant.fields {
+            Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+                let ty = format_type(&unnamed.unnamed[0].ty, dependencies, generics);
+                quote!(format!("{{ {}: \"{}\", {}: {} }}", #tag, #name, #content, #ty))
+            }
+            Fields::Unit => quote!(format!("{{ {}: \"{}\" }}", #tag, #name)),
+            _ => quote!(format!("{{ {}: \"{}\", {}: {} }}", #tag, #name, #content, #inline_type)),
+        },
+        Tagged::Internally { tag } => match variant_type.inline_flattened {
+            Some(inline_flattened) => quote! {
+                format!(
+                    "{{ {}: \"{}\", {} }}",
+                    #tag,
+                    #name,
+                    #inline_flattened
+                )
+            },
+            None => match &variant.fields {
+                Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+                    let ty = format_type(&unnamed.unnamed[0].ty, dependencies, generics);
+                    quote!(format!("{{ {}: \"{}\" }} & {}", #tag, #name, #ty))
+                }
+                Fields::Unit => quote!(format!("{{ {}: \"{}\" }}", #tag, #name)),
+                _ => {
+                    dependencies.append(variant_dependencies);
+                    quote!(format!("{{ {}: \"{}\" }} & {}", #tag, #name, #inline_type))
+                }
+            },
+        },
+    };
+
+    formatted_variants.push(formatted);
+    Ok(())
+}

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -37,6 +37,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
         inline_flattened: None,
         dependencies,
         name,
+        export: enum_attr.export,
     })
 }
 
@@ -70,7 +71,7 @@ fn format_variant(
         (None, Some(rn)) => rn.apply(&variant.ident.to_string()),
     };
 
-    let variant_type = types::type_def(&name, &None, &variant.fields, generics)?;
+    let variant_type = types::type_def(&name, &None, &variant.fields, generics, None)?;
     let variant_dependencies = variant_type.dependencies;
     let inline_type = variant_type.inline;
 

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -60,7 +60,7 @@ fn format_variant(
 
     match (skip, &type_override, inline, optional, flatten) {
         (true, ..) => return Ok(()),
-        (_, Some(_), ..) => syn_err!("`type_override` is not applicable to enum variants"),
+        (_, Some(_), ..) => syn_err!("`type` is not applicable to enum variants"),
         (_, _, _, true, ..) => syn_err!("`optional` is not applicable to enum variants"),
         (_, _, _, _, true) => syn_err!("`flatten` is not applicable to enum variants"),
         _ => {}

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{GenericArgument, GenericParam, Generics, PathArguments, Type};
+use quote::{quote, format_ident};
+use syn::{GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeTuple};
+use crate::attr::StructAttr;
 
 use crate::deps::Dependencies;
 
@@ -45,8 +46,33 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
         return quote!(#generic_ident.to_owned());
     }
 
-    dependencies.push_or_append_from(ty);
+    // special treatment for arrays and tuples
+    match ty {
+        // the field is an array (`[T; n]`) so it technically doesn't have a generic argument.
+        // therefore, we handle it explicitly here like a `Vec<T>`
+        Type::Array(array) => {
+            let inner_ty = &array.elem;
+            let vec_ty = syn::parse2::<Type>(quote!(Vec::<#inner_ty>)).unwrap();
+            return format_type(&vec_ty, dependencies, generics);
+        }
+        // same goes for a tuple (`(A, B, C)`) - it doesn't have a type arg, so we handle it
+        // explicitly here.
+        Type::Tuple(tuple) => {
+            // we convert the tuple field to a struct: `(A, B, C)` => `struct A(A, B, C)`
+            let tuple_struct = super::type_def(
+                &StructAttr::default(),
+                &format_ident!("_"),
+                &tuple_type_to_tuple_struct(tuple).fields,
+                generics
+            ).unwrap();
+            // now, we return the inline definition
+            dependencies.append(tuple_struct.dependencies);
+            return tuple_struct.inline;
+        }
+        _ => ()
+    };
 
+    dependencies.push_or_append_from(ty);
     match extract_type_args(ty) {
         None => quote!(<#ty as ts_rs::TS>::name()),
         Some(type_args) => {
@@ -84,4 +110,11 @@ fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
     }
 
     Some(type_args)
+}
+
+// convert a [`TypeTuple`],  e.g `(A, B, C)`
+//      to a [`ItemStruct`], e.g `struct A(A, B, C)`
+fn tuple_type_to_tuple_struct(tuple: &TypeTuple) -> ItemStruct {
+    let elements = tuple.elems.iter();
+    syn::parse2(quote!(struct A( #(#elements),* );)).expect("could not convert tuple to tuple struct")
 }

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -1,9 +1,8 @@
 use proc_macro2::TokenStream;
-use quote::{quote, format_ident};
+use quote::{format_ident, quote};
 use syn::{GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeTuple};
-use crate::attr::StructAttr;
 
-use crate::deps::Dependencies;
+use crate::{attr::StructAttr, deps::Dependencies};
 
 /// formats the generic arguments (like A, B in struct X<A, B>{..}) as "<X>" where x is a comma
 /// seperated list of generic arguments, or None if there are no generic arguments.
@@ -63,13 +62,14 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
                 &StructAttr::default(),
                 &format_ident!("_"),
                 &tuple_type_to_tuple_struct(tuple).fields,
-                generics
-            ).unwrap();
+                generics,
+            )
+            .unwrap();
             // now, we return the inline definition
             dependencies.append(tuple_struct.dependencies);
             return tuple_struct.inline;
         }
-        _ => ()
+        _ => (),
     };
 
     dependencies.push_or_append_from(ty);
@@ -116,5 +116,6 @@ fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
 //      to a [`ItemStruct`], e.g `struct A(A, B, C)`
 fn tuple_type_to_tuple_struct(tuple: &TypeTuple) -> ItemStruct {
     let elements = tuple.elems.iter();
-    syn::parse2(quote!(struct A( #(#elements),* );)).expect("could not convert tuple to tuple struct")
+    syn::parse2(quote!(struct A( #(#elements),* );))
+        .expect("could not convert tuple to tuple struct")
 }

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -4,6 +4,25 @@ use syn::{GenericArgument, GenericParam, Generics, PathArguments, Type};
 
 use crate::deps::Dependencies;
 
+/// formats the generic arguments (like A, B in struct X<A, B>{..}) as "<X>" where x is a comma
+/// seperated list of generic arguments, or None if there are no generic arguments.
+pub fn format_generics(generics: &Generics) -> Option<String> {
+    match &generics.params {
+        params if !params.is_empty() => {
+            let expanded_params = params
+                .iter()
+                .filter_map(|param| match param {
+                    GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            Some(format!("<{}>", expanded_params))
+        }
+        _ => None,
+    }
+}
+
 pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generics) -> TokenStream {
     // If the type matches one of the generic parameters, just pass the identifier:
     if let Some(generic_ident) = generics

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -16,10 +16,14 @@ mod unit;
 pub(crate) use r#enum::r#enum_def;
 
 pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
-    let StructAttr { rename_all, rename } = StructAttr::from_attrs(&s.attrs)?;
+    let StructAttr {
+        rename_all,
+        rename,
+        export,
+    } = StructAttr::from_attrs(&s.attrs)?;
     let name = rename.unwrap_or_else(|| to_ts_ident(&s.ident));
 
-    type_def(&name, &rename_all, &s.fields, &s.generics)
+    type_def(&name, &rename_all, &s.fields, &s.generics, export)
 }
 
 fn type_def(
@@ -27,17 +31,18 @@ fn type_def(
     rename_all: &Option<Inflection>,
     fields: &Fields,
     generics: &Generics,
+    export: Option<Option<String>>,
 ) -> Result<DerivedTS> {
     match fields {
         Fields::Named(named) => match named.named.len() {
-            0 => unit::unit(name, rename_all),
-            _ => named::named(name, rename_all, named, generics),
+            0 => unit::unit(name, rename_all, export),
+            _ => named::named(name, rename_all, named, generics, export),
         },
         Fields::Unnamed(unnamed) => match unnamed.unnamed.len() {
-            0 => unit::unit(name, rename_all),
-            1 => newtype::newtype(name, rename_all, unnamed, generics),
-            _ => tuple::tuple(name, rename_all, unnamed, generics),
+            0 => unit::unit(name, rename_all, export),
+            1 => newtype::newtype(name, rename_all, unnamed, generics, export),
+            _ => tuple::tuple(name, rename_all, unnamed, generics, export),
         },
-        Fields::Unit => unit::unit(name, rename_all),
+        Fields::Unit => unit::unit(name, rename_all, export),
     }
 }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -20,10 +20,18 @@ pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
         rename_all,
         rename,
         export,
+        export_to,
     } = StructAttr::from_attrs(&s.attrs)?;
     let name = rename.unwrap_or_else(|| to_ts_ident(&s.ident));
 
-    type_def(&name, &rename_all, &s.fields, &s.generics, export)
+    type_def(
+        &name,
+        &rename_all,
+        &s.fields,
+        &s.generics,
+        export,
+        export_to,
+    )
 }
 
 fn type_def(
@@ -31,18 +39,19 @@ fn type_def(
     rename_all: &Option<Inflection>,
     fields: &Fields,
     generics: &Generics,
-    export: Option<Option<String>>,
+    export: bool,
+    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     match fields {
         Fields::Named(named) => match named.named.len() {
-            0 => unit::unit(name, rename_all, export),
-            _ => named::named(name, rename_all, named, generics, export),
+            0 => unit::unit(name, rename_all, export, export_to),
+            _ => named::named(name, rename_all, named, generics, export, export_to),
         },
         Fields::Unnamed(unnamed) => match unnamed.unnamed.len() {
-            0 => unit::unit(name, rename_all, export),
-            1 => newtype::newtype(name, rename_all, unnamed, generics, export),
-            _ => tuple::tuple(name, rename_all, unnamed, generics, export),
+            0 => unit::unit(name, rename_all, export, export_to),
+            1 => newtype::newtype(name, rename_all, unnamed, generics, export, export_to),
+            _ => tuple::tuple(name, rename_all, unnamed, generics, export, export_to),
         },
-        Fields::Unit => unit::unit(name, rename_all, export),
+        Fields::Unit => unit::unit(name, rename_all, export, export_to),
     }
 }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -1,10 +1,6 @@
-use syn::{Fields, Generics, ItemStruct, Result, Ident};
+use syn::{Fields, Generics, Ident, ItemStruct, Result};
 
-use crate::{
-    attr::{StructAttr},
-    utils::to_ts_ident,
-    DerivedTS,
-};
+use crate::{attr::StructAttr, utils::to_ts_ident, DerivedTS};
 
 mod r#enum;
 mod generics;
@@ -18,12 +14,7 @@ pub(crate) use r#enum::r#enum_def;
 pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
     let attr = StructAttr::from_attrs(&s.attrs)?;
 
-    type_def(
-        &attr,
-        &s.ident,
-        &s.fields,
-        &s.generics,
-    )
+    type_def(&attr, &s.ident, &s.fields, &s.generics)
 }
 
 fn type_def(

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -9,14 +9,13 @@ use crate::{
     utils::to_ts_ident,
     DerivedTS,
 };
+use crate::attr::StructAttr;
 
 pub(crate) fn named(
+    attr: &StructAttr,
     name: &str,
-    rename_all: &Option<Inflection>,
     fields: &FieldsNamed,
     generics: &Generics,
-    export: bool,
-    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     let mut formatted_fields = vec![];
     let mut dependencies = Dependencies::default();
@@ -25,7 +24,7 @@ pub(crate) fn named(
             &mut formatted_fields,
             &mut dependencies,
             field,
-            rename_all,
+            &attr.rename_all,
             generics,
         )?;
     }
@@ -44,8 +43,8 @@ pub(crate) fn named(
         inline_flattened: Some(fields),
         name: name.to_owned(),
         dependencies,
-        export,
-        export_to,
+        export: attr.export,
+        export_to: attr.export_to.clone(),
     })
 }
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,13 +1,11 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{
-    Field, FieldsNamed, GenericArgument, GenericParam, Generics, PathArguments, Result, Type,
-};
+use syn::{Field, FieldsNamed, GenericArgument, Generics, PathArguments, Result, Type};
 
 use crate::{
     attr::{FieldAttr, Inflection},
     deps::Dependencies,
-    types::generics::format_type,
+    types::generics::{format_generics, format_type},
     utils::to_ts_ident,
     DerivedTS,
 };
@@ -31,20 +29,7 @@ pub(crate) fn named(
     }
 
     let fields = quote!(vec![#(#formatted_fields),*].join(" "));
-    let generic_args = match &generics.params {
-        params if !params.is_empty() => {
-            let expanded_params = params
-                .iter()
-                .filter_map(|param| match param {
-                    GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
-                    _ => None,
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            quote!(format!("<{}>", #expanded_params))
-        }
-        _ => quote!("".to_owned()),
-    };
+    let generic_args = format_generics(generics).unwrap_or_default();
 
     Ok(DerivedTS {
         inline: quote! {

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -15,7 +15,8 @@ pub(crate) fn named(
     rename_all: &Option<Inflection>,
     fields: &FieldsNamed,
     generics: &Generics,
-    export: Option<Option<String>>,
+    export: bool,
+    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     let mut formatted_fields = vec![];
     let mut dependencies = Dependencies::default();
@@ -44,6 +45,7 @@ pub(crate) fn named(
         name: name.to_owned(),
         dependencies,
         export,
+        export_to,
     })
 }
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -3,13 +3,12 @@ use quote::quote;
 use syn::{Field, FieldsNamed, GenericArgument, Generics, PathArguments, Result, Type};
 
 use crate::{
-    attr::{FieldAttr, Inflection},
+    attr::{FieldAttr, Inflection, StructAttr},
     deps::Dependencies,
     types::generics::{format_generics, format_type},
     utils::to_ts_ident,
     DerivedTS,
 };
-use crate::attr::StructAttr;
 
 pub(crate) fn named(
     attr: &StructAttr,

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -15,6 +15,7 @@ pub(crate) fn named(
     rename_all: &Option<Inflection>,
     fields: &FieldsNamed,
     generics: &Generics,
+    export: Option<Option<String>>,
 ) -> Result<DerivedTS> {
     let mut formatted_fields = vec![];
     let mut dependencies = Dependencies::default();
@@ -42,6 +43,7 @@ pub(crate) fn named(
         inline_flattened: Some(fields),
         name: name.to_owned(),
         dependencies,
+        export,
     })
 }
 

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -2,21 +2,20 @@ use quote::quote;
 use syn::{FieldsUnnamed, Generics, Result};
 
 use crate::{
-    attr::{FieldAttr, Inflection},
+    attr::{FieldAttr},
     deps::Dependencies,
     types::generics::{format_generics, format_type},
     DerivedTS,
 };
+use crate::attr::StructAttr;
 
 pub(crate) fn newtype(
+    attr: &StructAttr,
     name: &str,
-    rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
-    export: bool,
-    export_to: Option<String>,
 ) -> Result<DerivedTS> {
-    if rename_all.is_some() {
+    if attr.rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to newtype structs");
     }
     let inner = fields.unnamed.first().unwrap();
@@ -57,7 +56,7 @@ pub(crate) fn newtype(
         inline_flattened: None,
         name: name.to_owned(),
         dependencies,
-        export,
-        export_to,
+        export: attr.export,
+        export_to: attr.export_to.clone(),
     })
 }

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -13,6 +13,7 @@ pub(crate) fn newtype(
     rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
+    export: Option<Option<String>>,
 ) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to newtype structs");
@@ -55,5 +56,6 @@ pub(crate) fn newtype(
         inline_flattened: None,
         name: name.to_owned(),
         dependencies,
+        export,
     })
 }

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -13,7 +13,8 @@ pub(crate) fn newtype(
     rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
-    export: Option<Option<String>>,
+    export: bool,
+    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to newtype structs");
@@ -57,5 +58,6 @@ pub(crate) fn newtype(
         name: name.to_owned(),
         dependencies,
         export,
+        export_to,
     })
 }

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -4,7 +4,7 @@ use syn::{FieldsUnnamed, Generics, Result};
 use crate::{
     attr::{FieldAttr, Inflection},
     deps::Dependencies,
-    types::generics::format_type,
+    types::generics::{format_generics, format_type},
     DerivedTS,
 };
 
@@ -48,8 +48,9 @@ pub(crate) fn newtype(
         None => format_type(inner_ty, &mut dependencies, generics),
     };
 
+    let generic_args = format_generics(generics).unwrap_or_default();
     Ok(DerivedTS {
-        decl: quote!(format!("type {} = {};", #name, #inline_def)),
+        decl: quote!(format!("type {}{} = {};", #name, #generic_args, #inline_def)),
         inline: inline_def,
         inline_flattened: None,
         name: name.to_owned(),

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -2,12 +2,11 @@ use quote::quote;
 use syn::{FieldsUnnamed, Generics, Result};
 
 use crate::{
-    attr::{FieldAttr},
+    attr::{FieldAttr, StructAttr},
     deps::Dependencies,
     types::generics::{format_generics, format_type},
     DerivedTS,
 };
-use crate::attr::StructAttr;
 
 pub(crate) fn newtype(
     attr: &StructAttr,

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -14,6 +14,7 @@ pub(crate) fn tuple(
     rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
+    export: Option<Option<String>>,
 ) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to tuple structs");
@@ -44,6 +45,7 @@ pub(crate) fn tuple(
         inline_flattened: None,
         name: name.to_owned(),
         dependencies,
+        export,
     })
 }
 

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -14,7 +14,8 @@ pub(crate) fn tuple(
     rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
-    export: Option<Option<String>>,
+    export: bool,
+    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to tuple structs");
@@ -46,6 +47,7 @@ pub(crate) fn tuple(
         name: name.to_owned(),
         dependencies,
         export,
+        export_to,
     })
 }
 

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -3,21 +3,20 @@ use quote::quote;
 use syn::{Field, FieldsUnnamed, Generics, Result};
 
 use crate::{
-    attr::{FieldAttr, Inflection},
+    attr::{FieldAttr, },
     deps::Dependencies,
     types::generics::{format_generics, format_type},
     DerivedTS,
 };
+use crate::attr::StructAttr;
 
 pub(crate) fn tuple(
+    attr: &StructAttr,
     name: &str,
-    rename_all: &Option<Inflection>,
     fields: &FieldsUnnamed,
     generics: &Generics,
-    export: bool,
-    export_to: Option<String>,
 ) -> Result<DerivedTS> {
-    if rename_all.is_some() {
+    if attr.rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to tuple structs");
     }
 
@@ -46,8 +45,8 @@ pub(crate) fn tuple(
         inline_flattened: None,
         name: name.to_owned(),
         dependencies,
-        export,
-        export_to,
+        export: attr.export,
+        export_to: attr.export_to.clone(),
     })
 }
 

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -3,12 +3,11 @@ use quote::quote;
 use syn::{Field, FieldsUnnamed, Generics, Result};
 
 use crate::{
-    attr::{FieldAttr, },
+    attr::{FieldAttr, StructAttr},
     deps::Dependencies,
     types::generics::{format_generics, format_type},
     DerivedTS,
 };
-use crate::attr::StructAttr;
 
 pub(crate) fn tuple(
     attr: &StructAttr,

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -5,7 +5,7 @@ use syn::{Field, FieldsUnnamed, Generics, Result};
 use crate::{
     attr::{FieldAttr, Inflection},
     deps::Dependencies,
-    types::generics::format_type,
+    types::generics::{format_generics, format_type},
     DerivedTS,
 };
 
@@ -25,6 +25,7 @@ pub(crate) fn tuple(
         format_field(&mut formatted_fields, &mut dependencies, field, generics)?;
     }
 
+    let generic_args = format_generics(generics).unwrap_or_default();
     Ok(DerivedTS {
         inline: quote! {
             format!(
@@ -34,8 +35,9 @@ pub(crate) fn tuple(
         },
         decl: quote! {
             format!(
-                "type {} = {};",
+                "type {}{} = {};",
                 #name,
+                #generic_args,
                 Self::inline()
             )
         },

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -6,7 +6,8 @@ use crate::{attr::Inflection, deps::Dependencies, DerivedTS};
 pub(crate) fn unit(
     name: &str,
     rename_all: &Option<Inflection>,
-    export: Option<Option<String>>,
+    export: bool,
+    export_to: Option<String>,
 ) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to unit structs");
@@ -19,5 +20,6 @@ pub(crate) fn unit(
         name: name.to_owned(),
         dependencies: Dependencies::default(),
         export,
+        export_to,
     })
 }

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -1,15 +1,14 @@
 use quote::quote;
 use syn::Result;
 
-use crate::{attr::Inflection, deps::Dependencies, DerivedTS};
+use crate::{deps::Dependencies, DerivedTS};
+use crate::attr::StructAttr;
 
 pub(crate) fn unit(
+    attr: &StructAttr,
     name: &str,
-    rename_all: &Option<Inflection>,
-    export: bool,
-    export_to: Option<String>,
 ) -> Result<DerivedTS> {
-    if rename_all.is_some() {
+    if attr.rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to unit structs");
     }
 
@@ -19,7 +18,7 @@ pub(crate) fn unit(
         inline_flattened: None,
         name: name.to_owned(),
         dependencies: Dependencies::default(),
-        export,
-        export_to,
+        export: attr.export,
+        export_to: attr.export_to.clone(),
     })
 }

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -3,7 +3,11 @@ use syn::Result;
 
 use crate::{attr::Inflection, deps::Dependencies, DerivedTS};
 
-pub(crate) fn unit(name: &str, rename_all: &Option<Inflection>) -> Result<DerivedTS> {
+pub(crate) fn unit(
+    name: &str,
+    rename_all: &Option<Inflection>,
+    export: Option<Option<String>>,
+) -> Result<DerivedTS> {
     if rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to unit structs");
     }
@@ -14,5 +18,6 @@ pub(crate) fn unit(name: &str, rename_all: &Option<Inflection>) -> Result<Derive
         inline_flattened: None,
         name: name.to_owned(),
         dependencies: Dependencies::default(),
+        export,
     })
 }

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -1,13 +1,9 @@
 use quote::quote;
 use syn::Result;
 
-use crate::{deps::Dependencies, DerivedTS};
-use crate::attr::StructAttr;
+use crate::{attr::StructAttr, deps::Dependencies, DerivedTS};
 
-pub(crate) fn unit(
-    attr: &StructAttr,
-    name: &str,
-) -> Result<DerivedTS> {
+pub(crate) fn unit(attr: &StructAttr, name: &str) -> Result<DerivedTS> {
     if attr.rename_all.is_some() {
         syn_err!("`rename_all` is not applicable to unit structs");
     }

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -29,3 +29,4 @@ chrono = { version = "0.4.19", optional = true }
 bigdecimal = {version = ">=0.0.13, < 0.4.0", features=["serde"], optional = true}
 uuid = { version = "0.8.2", optional = true }
 bytes = { version = "1.0", optional = true }
+thiserror = "1"

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ts-rs"
-version = "5.1.1"
+version = "6.0.0"
 authors = ["Moritz Bischof <moritz.bischof1@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -17,13 +17,14 @@ bigdecimal-impl = ["bigdecimal"]
 uuid-impl = ["uuid"]
 bytes-impl = ["bytes"]
 serde-compat = ["ts-rs-macros/serde-compat"]
+default = ["serde-compat"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
-ts-rs-macros = { version = "5.1.0", path = "../macros" }
+ts-rs-macros = { version = "6.0.0", path = "../macros" }
 dprint-plugin-typescript = { version = "0.43" }
 chrono = { version = "0.4.19", optional = true }
 bigdecimal = {version = ">=0.0.13, < 0.4.0", features=["serde"], optional = true}

--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -1,0 +1,57 @@
+use chrono::{
+    Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone,
+    Utc,
+};
+
+use super::{impl_primitives, TS};
+use crate::Dependency;
+
+macro_rules! impl_dummy {
+    ($($t:ty),*) => {$(
+        impl TS for $t {
+            fn name() -> String { String::new() }
+            fn inline() -> String { String::new() }
+            fn dependencies() -> Vec<Dependency> { vec![] }
+            fn transparent() -> bool { false }
+        }
+    )*};
+}
+
+impl_primitives!(NaiveDateTime, NaiveDate, NaiveTime, Duration => "string");
+impl_dummy!(Utc, Local, FixedOffset);
+
+impl<T: TimeZone + 'static> TS for DateTime<T> {
+    fn name() -> String {
+        "string".to_owned()
+    }
+    fn name_with_type_args(_: Vec<String>) -> String {
+        Self::name()
+    }
+    fn inline() -> String {
+        "string".to_owned()
+    }
+    fn dependencies() -> Vec<Dependency> {
+        vec![]
+    }
+    fn transparent() -> bool {
+        false
+    }
+}
+
+impl<T: TimeZone + 'static> TS for Date<T> {
+    fn name() -> String {
+        "string".to_owned()
+    }
+    fn name_with_type_args(_: Vec<String>) -> String {
+        Self::name()
+    }
+    fn inline() -> String {
+        "string".to_owned()
+    }
+    fn dependencies() -> Vec<Dependency> {
+        vec![]
+    }
+    fn transparent() -> bool {
+        false
+    }
+}

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -165,12 +165,12 @@ pub fn imports<T: TS>(
 ) {
     T::dependencies()
         .into_iter()
-        .flat_map(|(id, name)| {
-            let path = exported_files.get(&id)?;
+        .flat_map(|dep| {
+            let path = exported_files.get(&dep.type_id)?;
             if path == out_path {
                 None
             } else {
-                Some((import_path(out_path, path), name))
+                Some((import_path(out_path, path), dep.ts_name))
             }
         })
         .for_each(|(path, name)| {
@@ -181,7 +181,9 @@ pub fn imports<T: TS>(
         });
 }
 
-fn import_path(from: &Path, import: &Path) -> String {
+/// Returns the required import path for importing `import` from the file `from`
+#[doc(hidden)]
+pub fn import_path(from: &Path, import: &Path) -> String {
     let rel_path =
         diff_paths(import, from.parent().unwrap()).expect("failed to calculate import path");
     match rel_path.components().next() {

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -69,7 +69,7 @@ fn generate_imports<T: TS + ?Sized>(out: &mut String) -> Result<(), ExportError>
 
     for dep in deps {
         let rel_path = import_path(path, Path::new(dep.exported_to));
-        writeln!(out, "import {{ {} }} from {:?};", &dep.ts_name, rel_path).unwrap();
+        writeln!(out, "import type {{ {} }} from {:?};", &dep.ts_name, rel_path).unwrap();
     }
     writeln!(out).unwrap();
     Ok(())

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -1,189 +1,71 @@
 use std::{
     any::TypeId,
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     fmt::Write,
     path::{Component, Path, PathBuf},
 };
 
+pub use dprint_plugin_typescript::{configuration::ConfigurationBuilder, format_text};
+use thiserror::Error;
+
 use crate::TS;
 
-/// Expands to a test function which exports typescript bindings to one or multiple files when
-/// running `cargo test`.  
-/// If a type depends on an other type which is exported to a different file, an appropriate import
-/// will be included.  
-/// If a file already exists, it will be overriden.  
-/// Missing parent directories of the file(s) will be created.  
-/// Paths are interpreted as being relative to the project root.
-/// ```rust
-/// # use ts_rs::{export, TS};
-/// #[derive(TS)] struct A;
-/// #[derive(TS)] struct B;
-/// #[derive(TS)] struct C;
-///
-/// export! {
-///     A, B => "bindings/a.ts",
-///     C => "bindings/b.ts"
-/// }
-/// ```
-/// When running `cargo test`, bindings for `A`, `B` and `C` will be exported to `bindings/a.ts`
-/// and `bindings/b.ts`.
-///
-/// By default, `export!` always uses `export type/interface`.
-/// If you wish, you can also use ambient declarations (`declare type/interface`):
-/// ```rust
-/// # use ts_rs::{export, TS};
-/// #[derive(TS)] struct Declared;
-/// #[derive(TS)] struct Normal(Declared);
-///
-/// export! {
-///     (declare) Declared => "bindings/declared.d.ts",
-///     Normal => "bindings/normal.ts"
-/// }
-/// ```
-/// Since `Declared` is now an ambient declaration, `bindings/normal.ts` will not include an import
-/// for `bindings/declared.d.ts`.
-#[macro_export]
-macro_rules! export {
-    ($($arg:tt)*) => {
-        #[cfg(test)]
-        #[test]
-        fn export_typescript() {
-             ts_rs::export_here!($($arg)*)
-        }
-    };
+/// An error which may occur when exporting a type
+#[derive(Error, Debug)]
+pub enum ExportError {
+    #[error("this type cannot be exported")]
+    CannotBeExported,
+    #[error("an error occurred while formatting the generated typescript output")]
+    Formatting(String),
+    #[error("an error occurred while performing IO")]
+    Io(#[from] std::io::Error),
 }
 
-/// Like `export!` but instead of creating a test function it executes the binding generation right here.
-/// This may be useful if you'd like to run the binding generation in any other context than a test.
-#[macro_export]
-macro_rules! export_here {
-    ($($(($decl:ident))? $($p:path),+ => $l:expr),* $(,)?) => {
-        {
-            use std::fmt::Write;
-            use std::collections::{BTreeMap as __BTreeMap, BTreeSet as __BTreeSet};
+/// Export `T` to the file specified by the `#[ts(export = ..)]` attribute and/or the `out_dir`
+/// setting in the `ts.toml` config file.
+pub(crate) fn export_type<T: TS + ?Sized>() -> Result<(), ExportError> {
+    let path = Path::new(T::EXPORT_TO.ok_or(ExportError::CannotBeExported)?);
 
-            let manifest_var = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-            let manifest_dir = std::path::Path::new(&manifest_var);
+    let mut buffer = String::with_capacity(1024);
+    generate_imports::<T>(&mut buffer)?;
+    generate_decl::<T>(&mut buffer);
 
-            // {TypeId} -> {PathBuf}
-            let mut files = __BTreeMap::new();
-            $(
-                let path = manifest_dir.join($l);
+    // format output
+    let fmt_cfg = ConfigurationBuilder::new().deno().build();
+    let buffer = format_text(path, &buffer, &fmt_cfg).map_err(ExportError::Formatting)?;
 
-                // if the type(s) should be `declare`d, then they should not be imported.
-                let mut declared = false;
-                $( ts_rs::check_declare!($decl); declared = true; )*;
-
-                if !declared {
-                    $({
-                        if let Some(_) = files.insert(std::any::TypeId::of::<$p>(), path.clone()) {
-                            panic!(
-                                "{} cannot be exported to multiple files using `export!`",
-                                stringify!($p),
-                            );
-                        }
-                    })*
-                }
-            )*
-
-            let mut buffer = String::with_capacity(8192);
-            let mut imports = __BTreeMap::<String, __BTreeSet<String>>::new();
-            let fmt_config = ts_rs::export::FmtCfg::new() .deno().build();
-
-            $({
-                // clear buffers
-                buffer.clear();
-                imports.clear();
-
-                // create output directory
-                let out = manifest_dir.join($l);
-                std::fs::create_dir_all(out.parent().unwrap())
-                    .expect("could not create directory");
-
-                // write imports
-                $( ts_rs::export::imports::<$p>(&files, &mut imports, &out); )*
-                ts_rs::export::write_imports(&imports, &mut buffer);
-                buffer.push_str("\n");
-
-                // write declarations
-
-                // check if `export` or `declare` should be used
-                let mut prefix = "export ";
-                $( ts_rs::check_declare!($decl); prefix = "declare "; )*;
-
-                $(
-                    buffer.push_str(prefix);
-                    buffer.push_str(&<$p as ts_rs::TS>::decl());
-                    buffer.push_str("\n\n");
-                )*
-
-                // format output
-                let buffer = ts_rs::export::fmt_ts(&out, &buffer, &fmt_config)
-                    .expect("could not format output");
-
-                std::fs::write(&out, buffer.trim())
-                    .expect("could not write file");
-            })*
-        }
-    };
-}
-
-// checks that the given argument is `declare`, emitting a compile_error! if it isn't.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! check_declare {
-    (declare) => {};
-    ($x:ident) => {
-        compile_error!(concat!(
-            "expected `(declare)`, got `(",
-            stringify!($x),
-            ")`"
-        ));
-    };
-}
-
-pub use dprint_plugin_typescript::{
-    configuration::ConfigurationBuilder as FmtCfg, format_text as fmt_ts,
-};
-
-pub fn write_imports(imports: &BTreeMap<String, BTreeSet<String>>, out: &mut impl Write) {
-    for (path, types) in imports {
-        writeln!(
-            out,
-            "import {{{}}} from {:?};",
-            types.iter().cloned().collect::<Vec<_>>().join(", "),
-            path
-        )
-        .unwrap();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
     }
+    std::fs::write(path, &buffer)?;
+    Ok(())
 }
 
-pub fn imports<T: TS>(
-    exported_files: &BTreeMap<TypeId, PathBuf>,
-    imports: &mut BTreeMap<String, BTreeSet<String>>,
-    out_path: &Path,
-) {
-    T::dependencies()
+/// Push the declaration of `T`
+fn generate_decl<T: TS + ?Sized>(out: &mut String) {
+    out.push_str("export ");
+    out.push_str(&T::decl());
+}
+
+/// Push an import statement for all dependencies of `T`
+fn generate_imports<T: TS + ?Sized>(out: &mut String) -> Result<(), ExportError> {
+    let path = Path::new(T::EXPORT_TO.ok_or(ExportError::CannotBeExported)?);
+
+    let deps = T::dependencies()
         .into_iter()
-        .flat_map(|dep| {
-            let path = exported_files.get(&dep.type_id)?;
-            if path == out_path {
-                None
-            } else {
-                Some((import_path(out_path, path), dep.ts_name))
-            }
-        })
-        .for_each(|(path, name)| {
-            imports
-                .entry(path)
-                .or_insert_with(BTreeSet::<_>::new)
-                .insert(name);
-        });
+        .filter(|dep| dep.type_id != TypeId::of::<T>())
+        .collect::<BTreeSet<_>>();
+
+    for dep in deps {
+        let rel_path = import_path(path, Path::new(dep.exported_to));
+        writeln!(out, "import {{ {} }} from {:?};", &dep.ts_name, rel_path).unwrap();
+    }
+    writeln!(out).unwrap();
+    Ok(())
 }
 
 /// Returns the required import path for importing `import` from the file `from`
-#[doc(hidden)]
-pub fn import_path(from: &Path, import: &Path) -> String {
+fn import_path(from: &Path, import: &Path) -> String {
     let rel_path =
         diff_paths(import, from.parent().unwrap()).expect("failed to calculate import path");
     match rel_path.components().next() {

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -69,7 +69,12 @@ fn generate_imports<T: TS + ?Sized>(out: &mut String) -> Result<(), ExportError>
 
     for dep in deps {
         let rel_path = import_path(path, Path::new(dep.exported_to));
-        writeln!(out, "import type {{ {} }} from {:?};", &dep.ts_name, rel_path).unwrap();
+        writeln!(
+            out,
+            "import type {{ {} }} from {:?};",
+            &dep.ts_name, rel_path
+        )
+        .unwrap();
     }
     writeln!(out).unwrap();
     Ok(())

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ## why?
 //! When building a web application in rust, data structures have to be shared between backend and frontend.
-//! Using this library, you can easily generate TypeScript bindings to your rust structs & enums, so that you can keep your
+//! Using this library, you can easily generate TypeScript bindings to your rust structs & enums so that you can keep your
 //! types in one place.
 //!
 //! ts-rs might also come in handy when working with webassembly.
@@ -34,7 +34,8 @@
 //! ## how?
 //! ts-rs exposes a single trait, `TS`. Using a derive macro, you can implement this interface for your types.
 //! Then, you can use this trait to obtain the TypeScript bindings.
-//! We recommend doing this in your tests. [See the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs) and [the docs](https://docs.rs/ts-rs/latest/ts_rs/).
+//! We recommend doing this in your tests.
+//! [See the example](https://github.com/Aleph-Alpha/ts-rs/blob/main/example/src/lib.rs) and [the docs](https://docs.rs/ts-rs/latest/ts_rs/).
 //!
 //! ## get started
 //! ```toml
@@ -43,7 +44,7 @@
 //! ```
 //!
 //! ```rust
-//! use ts_rs::{TS, export};
+//! use ts_rs::TS;
 //!
 //! #[derive(TS)]
 //! #[ts(export)]
@@ -63,6 +64,20 @@
 //! - generate necessary imports when exporting to multiple files
 //! - serde compatibility
 //! - generic types
+//!
+//! ## cargo features
+//! - `serde-compat` (default)  
+//!   Enable serde compatibility. See below for more info.  
+//! - `chrono-impl`  
+//!   Implement `TS` for types from chrono  
+//! - `bigdecimal-impl`  
+//!   Implement `TS` for types from bigdecimal  
+//! - `uuid-impl`  
+//!   Implement `TS` for types from uuid  
+//! - `bytes-impl`  
+//!   Implement `TS` for types from bytes  
+//!
+//! If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 //!
 //! ## serde compatability
 //! With the `serde-compat` feature (enabled by default), serde attributes can be parsed for enums and structs.
@@ -84,7 +99,7 @@
 //! ## contributing
 //! Contributions are always welcome!
 //! Feel free to open an issue, discuss using GitHub discussions or open a PR.
-//! [see CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
+//! [See CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
 //!
 //! ## todo
 //! - [x] serde compatibility layer
@@ -128,17 +143,17 @@ mod export;
 /// ### container attributes
 /// attributes applicable for both structs and enums
 ///
-/// - `#[ts(export)]`:
+/// - `#[ts(export)]`:  
 ///   Generates a test which will export the type, by default to `bindings/<name>.ts` when running
 ///   `cargo test`
 ///
-/// - `#[ts(export_to = "..")]`:
+/// - `#[ts(export_to = "..")]`:  
 ///   Specifies where the type should be exported to. Defaults to `bindings/<name>.ts`.
 ///
-/// - `#[ts(rename = "..")]`:
+/// - `#[ts(rename = "..")]`:  
 ///   Sets the typescript name of the generated type
 ///
-/// - `#[ts(rename_all = "..")]`:
+/// - `#[ts(rename_all = "..")]`:  
 ///   Rename all fields/variants of the type.
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`
 ///
@@ -146,7 +161,8 @@ mod export;
 /// ### struct field attributes
 ///
 /// - `#[ts(type = "..")]`:  
-///   Overrides the type used in TypeScript  
+///   Overrides the type used in TypeScript.  
+///   This is useful when there's a type for which you cannot derive `TS`.  
 ///
 /// - `#[ts(rename = "..")]`:  
 ///   Renames this field  
@@ -157,7 +173,7 @@ mod export;
 /// - `#[ts(skip)]`:  
 ///   Skip this field  
 ///
-/// - `#[ts(optional)]`:
+/// - `#[ts(optional)]`:  
 ///   Indicates the field may be omitted from the serialized struct
 ///
 /// - `#[ts(flatten)]`:  
@@ -165,15 +181,15 @@ mod export;
 ///   
 /// ### enum attributes
 ///
-/// - `#[ts(tag = "..")]`:
+/// - `#[ts(tag = "..")]`:  
 ///   Changes the representation of the enum to store its tag in a separate field.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///
-/// - `#[ts(content = "..")]`:
+/// - `#[ts(content = "..")]`:  
 ///   Changes the representation of the enum to store its content in a separate field.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///
-/// - `#[ts(untagged)]`:
+/// - `#[ts(untagged)]`:  
 ///   Changes the representation of the enum to not include its tag.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -175,18 +175,10 @@ impl Dependency {
 macro_rules! impl_primitives {
     ($($($ty:ty),* => $l:literal),*) => { $($(
         impl TS for $ty {
-            fn name() -> String {
-                $l.to_owned()
-            }
-            fn inline() -> String {
-                $l.to_owned()
-            }
-            fn dependencies() -> Vec<Dependency> {
-                vec![]
-            }
-            fn transparent() -> bool {
-                false
-            }
+            fn name() -> String { $l.to_owned() }
+            fn inline() -> String { $l.to_owned() }
+            fn dependencies() -> Vec<Dependency> { vec![] }
+            fn transparent() -> bool { false }
         }
     )*)* };
 }
@@ -309,28 +301,43 @@ mod bytes {
 
 #[cfg(feature = "chrono-impl")]
 mod chrono_impls {
-    use chrono::{Date, DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone};
+    use chrono::{
+        Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime,
+        TimeZone, Utc,
+    };
 
     use super::TS;
     use crate::Dependency;
 
-    impl_primitives! {
-        NaiveDateTime, NaiveDate, NaiveTime => "string"
+    macro_rules! impl_dummy {
+        ($($t:ty),*) => {$(
+            impl TS for $t {
+                fn name() -> String { String::new() }
+                fn inline() -> String { String::new() }
+                fn dependencies() -> Vec<Dependency> { vec![] }
+                fn transparent() -> bool { false }
+            }
+        )*};
     }
+
+    impl_primitives! {
+        NaiveDateTime, NaiveDate, NaiveTime, Duration => "string"
+    }
+    impl_dummy!(Utc, Local, FixedOffset);
 
     impl<T: TimeZone + 'static> TS for DateTime<T> {
         fn name() -> String {
             "string".to_owned()
         }
-
+        fn name_with_type_args(_: Vec<String>) -> String {
+            Self::name()
+        }
         fn inline() -> String {
             "string".to_owned()
         }
-
         fn dependencies() -> Vec<Dependency> {
             vec![]
         }
-
         fn transparent() -> bool {
             false
         }
@@ -340,15 +347,15 @@ mod chrono_impls {
         fn name() -> String {
             "string".to_owned()
         }
-
+        fn name_with_type_args(_: Vec<String>) -> String {
+            Self::name()
+        }
         fn inline() -> String {
             "string".to_owned()
         }
-
         fn dependencies() -> Vec<Dependency> {
             vec![]
         }
-
         fn transparent() -> bool {
             false
         }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -27,6 +27,8 @@ pub use ts_rs_macros::TS;
 
 pub use crate::export::ExportError;
 
+#[cfg(feature = "chrono-impl")]
+mod chrono;
 mod export;
 
 /// A type which can be represented in TypeScript.  
@@ -182,6 +184,7 @@ macro_rules! impl_primitives {
         }
     )*)* };
 }
+pub(crate) use impl_primitives;
 
 macro_rules! impl_tuples {
     ( impl $($i:ident),* ) => {
@@ -295,69 +298,6 @@ mod bytes {
 
         fn transparent() -> bool {
             true
-        }
-    }
-}
-
-#[cfg(feature = "chrono-impl")]
-mod chrono_impls {
-    use chrono::{
-        Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime,
-        TimeZone, Utc,
-    };
-
-    use super::TS;
-    use crate::Dependency;
-
-    macro_rules! impl_dummy {
-        ($($t:ty),*) => {$(
-            impl TS for $t {
-                fn name() -> String { String::new() }
-                fn inline() -> String { String::new() }
-                fn dependencies() -> Vec<Dependency> { vec![] }
-                fn transparent() -> bool { false }
-            }
-        )*};
-    }
-
-    impl_primitives! {
-        NaiveDateTime, NaiveDate, NaiveTime, Duration => "string"
-    }
-    impl_dummy!(Utc, Local, FixedOffset);
-
-    impl<T: TimeZone + 'static> TS for DateTime<T> {
-        fn name() -> String {
-            "string".to_owned()
-        }
-        fn name_with_type_args(_: Vec<String>) -> String {
-            Self::name()
-        }
-        fn inline() -> String {
-            "string".to_owned()
-        }
-        fn dependencies() -> Vec<Dependency> {
-            vec![]
-        }
-        fn transparent() -> bool {
-            false
-        }
-    }
-
-    impl<T: TimeZone + 'static> TS for Date<T> {
-        fn name() -> String {
-            "string".to_owned()
-        }
-        fn name_with_type_args(_: Vec<String>) -> String {
-            Self::name()
-        }
-        fn inline() -> String {
-            "string".to_owned()
-        }
-        fn dependencies() -> Vec<Dependency> {
-            vec![]
-        }
-        fn transparent() -> bool {
-            false
         }
     }
 }

--- a/ts-rs/tests/arrays.rs
+++ b/ts-rs/tests/arrays.rs
@@ -1,6 +1,14 @@
 use ts_rs::TS;
 
 #[test]
+fn free() {
+    assert_eq!(
+        <[String; 10]>::inline(),
+        "Array<string>"
+    )
+}
+
+#[test]
 fn interface() {
     #[derive(TS)]
     struct Interface {

--- a/ts-rs/tests/arrays.rs
+++ b/ts-rs/tests/arrays.rs
@@ -2,10 +2,7 @@ use ts_rs::TS;
 
 #[test]
 fn free() {
-    assert_eq!(
-        <[String; 10]>::inline(),
-        "Array<string>"
-    )
+    assert_eq!(<[String; 10]>::inline(), "Array<string>")
 }
 
 #[test]

--- a/ts-rs/tests/chrono.rs
+++ b/ts-rs/tests/chrono.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "chrono-impl")]
+
 use chrono::{
     Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc,
 };

--- a/ts-rs/tests/chrono.rs
+++ b/ts-rs/tests/chrono.rs
@@ -1,13 +1,21 @@
-use chrono::{Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use chrono::{
+    Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc,
+};
 use ts_rs::TS;
 
 #[test]
 fn chrono() {
     #[derive(TS)]
+    #[allow(dead_code)]
     struct Chrono {
         date: (NaiveDate, Date<Utc>, Date<Local>, Date<FixedOffset>),
         time: NaiveTime,
-        date_time: (NaiveDateTime, DateTime<Utc>, DateTime<Local>, DateTime<FixedOffset>),
+        date_time: (
+            NaiveDateTime,
+            DateTime<Utc>,
+            DateTime<Local>,
+            DateTime<FixedOffset>,
+        ),
         duration: Duration,
     }
 

--- a/ts-rs/tests/chrono.rs
+++ b/ts-rs/tests/chrono.rs
@@ -1,0 +1,18 @@
+use chrono::{Date, DateTime, Duration, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use ts_rs::TS;
+
+#[test]
+fn chrono() {
+    #[derive(TS)]
+    struct Chrono {
+        date: (NaiveDate, Date<Utc>, Date<Local>, Date<FixedOffset>),
+        time: NaiveTime,
+        date_time: (NaiveDateTime, DateTime<Utc>, DateTime<Local>, DateTime<FixedOffset>),
+        duration: Duration,
+    }
+
+    assert_eq!(
+        Chrono::decl(),
+        "interface Chrono { date: [string, string, string, string], time: string, date_time: [string, string, string, string], duration: string, }"
+    )
+}

--- a/ts-rs/tests/export_here.rs
+++ b/ts-rs/tests/export_here.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 
-use std::{concat, env, fs};
+use std::{concat, fs};
 
 use ts_rs::TS;
 
 #[derive(TS)]
+#[ts(export_to = "export_here_test.ts")]
 struct User {
     name: String,
     age: i32,
@@ -13,19 +14,17 @@ struct User {
 
 #[test]
 fn test_export_here() {
-    let dir = env::temp_dir();
-    let file_path = dir.join("User.ts");
-    ts_rs::export_here!(User => file_path.to_str().unwrap());
+    User::export().unwrap();
 
     let expected_content = concat!(
         "export interface User {\n",
         "  name: string;\n",
         "  age: number;\n",
         "  active: boolean;\n",
-        "}"
+        "}\n"
     );
 
-    let actual_content = fs::read_to_string(file_path).unwrap();
+    let actual_content = fs::read_to_string("export_here_test.ts").unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -13,7 +13,7 @@ struct User {
 }
 
 #[test]
-fn test_export_here() {
+fn export_manually() {
     User::export().unwrap();
 
     let expected_content = concat!(

--- a/ts-rs/tests/generic_fields.rs
+++ b/ts-rs/tests/generic_fields.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use ts_rs::TS;
+use ts_rs::{Dependency, TS};
 
 #[test]
 fn newtype() {
@@ -32,8 +32,13 @@ fn named() {
     #[derive(TS)]
     struct Struct {
         a: Vec<String>,
+        b: (Vec<String>, Vec<String>),
+        c: [Vec<String>; 3],
     }
-    assert_eq!(Struct::inline(), "{ a: Array<string>, }");
+    assert_eq!(
+        Struct::inline(),
+        "{ a: Array<string>, b: [Array<string>, Array<string>], c: Array<Array<string>>, }"
+    );
 }
 
 #[test]
@@ -41,23 +46,32 @@ fn named_nested() {
     #[derive(TS)]
     struct Struct {
         a: Vec<Vec<String>>,
+        b: (Vec<Vec<String>>, Vec<Vec<String>>),
+        c: [Vec<Vec<String>>; 3],
     }
-    assert_eq!(Struct::inline(), "{ a: Array<Array<string>>, }");
+    assert_eq!(Struct::inline(), "{ a: Array<Array<string>>, b: [Array<Array<string>>, Array<Array<string>>], c: Array<Array<Array<string>>>, }");
 }
 
 #[test]
 fn tuple() {
     #[derive(TS)]
-    struct Tuple(Vec<i32>, Vec<i32>);
-    assert_eq!(Tuple::inline(), "[Array<number>, Array<number>]");
+    struct Tuple(Vec<i32>, (Vec<i32>, Vec<i32>), [Vec<i32>; 3]);
+    assert_eq!(
+        Tuple::inline(),
+        "[Array<number>, [Array<number>, Array<number>], Array<Array<number>>]"
+    );
 }
 
 #[test]
 fn tuple_nested() {
     #[derive(TS)]
-    struct Tuple(Vec<Vec<i32>>, Vec<Vec<i32>>);
+    struct Tuple(
+        Vec<Vec<i32>>,
+        (Vec<Vec<i32>>, Vec<Vec<i32>>),
+        [Vec<Vec<i32>>; 3],
+    );
     assert_eq!(
         Tuple::inline(),
-        "[Array<Array<number>>, Array<Array<number>>]"
+        "[Array<Array<number>>, [Array<Array<number>>, Array<Array<number>>], Array<Array<Array<number>>>]"
     );
 }

--- a/ts-rs/tests/generic_fields.rs
+++ b/ts-rs/tests/generic_fields.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use ts_rs::{Dependency, TS};
+use ts_rs::TS;
 
 #[test]
 fn newtype() {

--- a/ts-rs/tests/generic_fields.rs
+++ b/ts-rs/tests/generic_fields.rs
@@ -1,6 +1,7 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::box_collection)]
 
 use std::borrow::Cow;
+
 use ts_rs::TS;
 
 #[test]

--- a/ts-rs/tests/generic_fields.rs
+++ b/ts-rs/tests/generic_fields.rs
@@ -1,10 +1,12 @@
 #![allow(dead_code)]
+
+use std::borrow::Cow;
 use ts_rs::TS;
 
 #[test]
 fn newtype() {
     #[derive(TS)]
-    struct Newtype(Vec<i32>);
+    struct Newtype(Vec<Cow<'static, i32>>);
     assert_eq!(Newtype::inline(), "Array<number>");
 }
 
@@ -31,7 +33,7 @@ fn alias_nested() {
 fn named() {
     #[derive(TS)]
     struct Struct {
-        a: Vec<String>,
+        a: Box<Vec<String>>,
         b: (Vec<String>, Vec<String>),
         c: [Vec<String>; 3],
     }

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashSet};
+use std::rc::Rc;
 
 use ts_rs::TS;
 
@@ -31,8 +32,8 @@ where
 #[derive(TS)]
 struct Container {
     foo: Generic<u32>,
-    bar: Vec<Generic<u32>>,
-    baz: HashMap<String, Generic<String>>,
+    bar: Box<HashSet<Generic<u32>>>,
+    baz: Box<BTreeMap<String, Rc<Generic<String>>>>,
 }
 
 #[test]

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
-use std::collections::{BTreeMap, HashSet};
-use std::rc::Rc;
+use std::{
+    collections::{BTreeMap, HashSet},
+    rc::Rc,
+};
 
 use ts_rs::TS;
 
@@ -112,7 +114,7 @@ fn generic_struct() {
         e: [(T, T); 3],
         f: Vec<T>,
         g: Vec<Vec<T>>,
-        h: Vec<[(T, T); 3]>
+        h: Vec<[(T, T); 3]>,
     }
 
     assert_eq!(

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -57,3 +57,45 @@ fn test() {
         "interface Container { foo: Generic<number>, bar: Array<Generic<number>>, baz: Record<string, Generic<string>>, }"
     );
 }
+
+#[test]
+fn generic_enum() {
+    #[derive(TS)]
+    enum Generic<A, B, C> {
+        A(A),
+        B(B, B, B),
+        C(Vec<C>),
+        D(Vec<Vec<Vec<A>>>),
+        E { a: A, b: B, c: C },
+        X(Vec<i32>),
+        Y(i32),
+        Z(Vec<Vec<i32>>),
+    }
+
+    assert_eq!(
+        Generic::<(), (), ()>::decl(),
+        r#"type Generic<A, B, C> = { A: A } | { B: [B, B, B] } | { C: Array<C> } | { D: Array<Array<Array<A>>> } | { E: { a: A, b: B, c: C, } } | { X: Array<number> } | { Y: number } | { Z: Array<Array<number>> };"#
+    )
+}
+
+#[test]
+fn generic_newtype() {
+    #[derive(TS)]
+    struct NewType<T>(Vec<Vec<T>>);
+
+    assert_eq!(
+        NewType::<()>::decl(),
+        r#"type NewType<T> = Array<Array<T>>;"#
+    );
+}
+
+#[test]
+fn generic_tuple() {
+    #[derive(TS)]
+    struct Tuple<T>(T, Vec<T>, Vec<Vec<T>>);
+
+    assert_eq!(
+        Tuple::<()>::decl(),
+        r#"type Tuple<T> = [T, Array<T>, Array<Array<T>>];"#
+    );
+}

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -99,3 +99,23 @@ fn generic_tuple() {
         r#"type Tuple<T> = [T, Array<T>, Array<Array<T>>];"#
     );
 }
+
+#[test]
+fn generic_struct() {
+    #[derive(TS)]
+    struct Struct<T> {
+        a: T,
+        b: (T, T),
+        c: (T, (T, T)),
+        d: [T; 3],
+        e: [(T, T); 3],
+        f: Vec<T>,
+        g: Vec<Vec<T>>,
+        h: Vec<[(T, T); 3]>
+    }
+
+    assert_eq!(
+        Struct::<()>::decl(),
+        "interface Struct<T> { a: T, b: [T, T], c: [T, [T, T]], d: Array<T>, e: Array<[T, T]>, f: Array<T>, g: Array<Array<T>>, h: Array<Array<[T, T]>>, }"
+    )
+}

--- a/ts-rs/tests/nested.rs
+++ b/ts-rs/tests/nested.rs
@@ -1,8 +1,7 @@
 #![allow(dead_code)]
 
-use std::cell::Cell;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::{cell::Cell, rc::Rc, sync::Arc};
+
 use ts_rs::TS;
 
 #[derive(TS)]

--- a/ts-rs/tests/nested.rs
+++ b/ts-rs/tests/nested.rs
@@ -1,23 +1,26 @@
 #![allow(dead_code)]
 
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::Arc;
 use ts_rs::TS;
 
 #[derive(TS)]
 struct A {
-    x1: i32,
-    y1: i32,
+    x1: Arc<i32>,
+    y1: Cell<i32>,
 }
 
 #[derive(TS)]
 struct B {
-    a1: A,
+    a1: Box<A>,
     #[ts(inline)]
     a2: A,
 }
 
 #[derive(TS)]
 struct C {
-    b1: B,
+    b1: Rc<B>,
     #[ts(inline)]
     b2: B,
 }

--- a/ts-rs/tests/simple.rs
+++ b/ts-rs/tests/simple.rs
@@ -1,12 +1,13 @@
 #![allow(dead_code)]
 
+use std::cell::RefCell;
 use ts_rs::TS;
 
 #[derive(TS)]
 struct Simple {
     a: i32,
     b: String,
-    c: (i32, String, i32),
+    c: (i32, String, RefCell<i32>),
     d: Vec<String>,
     e: Option<String>,
 }

--- a/ts-rs/tests/simple.rs
+++ b/ts-rs/tests/simple.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::cell::RefCell;
+
 use ts_rs::TS;
 
 #[derive(TS)]

--- a/ts-rs/tests/type_override.rs
+++ b/ts-rs/tests/type_override.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 
 use ts_rs::TS;
 
-
 struct Unsupported<T>(T);
 struct Unsupported2;
 
@@ -18,7 +17,7 @@ struct Override {
     #[ts(type = "string")]
     y: Unsupported<Unsupported<Unsupported2>>,
     #[ts(type = "string | null")]
-    z: Option<Unsupported2>
+    z: Option<Unsupported2>,
 }
 
 #[test]

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, clippy::blacklisted_name)]
 
 use serde::Serialize;
 use ts_rs::TS;


### PR DESCRIPTION
This is the next big release for ts-rs

## Features
### New export logic
- remove `export!` and `export_here!`
- when deriving `TS`, `#[ts(export_to = "path")]` can be used to specify the output file.  
  with `#[ts(export)]`, a test which exports the type on `cargo test` will be generated.  

While this means that an exported typescript file will from now on only include one type, it makes exporting types from all over your project much easier. Currently, it's neccessary to export them all in one single invocation of `export!`, requiring that you adjust the visibility of your types.   

### Serde compatibility
Serde compatibility, which currently needs to be enabled by using the `serde-compat` feature, is now on by default.  
It can be disabled using `ts_rs = { version = "..", default_features = false, features = [..] }`

### Enum representations 
Enum representations are now by default compatible with serde, making "externally tagged" the default.  
Until now, the default behaviour was "untagged", which is still possible by using `#[serde(untagged)]` or `#[ts(untagged)]`.  
The other representations, "adjacently tagged" and "internally tagged" are still supported and 100% compatible with serde using `#[ts(tag = "..", content = "..")]` or `#[serde(tag = "..", content = "..")]`

### (More to be added)

## Fixes
### Generics
Generics are now properly handled in all cases, including newtypes, tuples, tuple/array fields in structs etc.
### Chrono
The chrono support works now - it was previously broken, requiring that `Utc` and other timezones implement `TS`
 
## Internal changes
This also includes a wide range of internal refactorings & cleanup, hopefully improving maintainability.