### PR TITLE
Allow defaults

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -102,6 +102,6 @@ enum InlineComplexEnum {
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 struct ComplexStruct {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub string_tree: Option<Rc<BTreeSet<String>>>,
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -60,6 +60,7 @@ where
 }
 
 #[derive(Serialize, TS)]
+#[serde(default)]
 #[ts(export)]
 struct Series {
     points: Vec<Point<u64>>,
@@ -101,6 +102,6 @@ enum InlineComplexEnum {
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 struct ComplexStruct {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub string_tree: Option<Rc<BTreeSet<String>>>,
 }

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -66,10 +66,6 @@ impl_parse! {
         "skip_deserializing" => out.0.skip = true,
         "skip_serializing_if" => out.0.optional = parse_assign_str(input)? == *"Option::is_none",
         "flatten" => out.0.flatten = true,
-        "default" => {
-            if !input.is_empty() {
-                parse_assign_str(input)?;
-            }
-        },
+        "default" => {},
     }
 }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -58,5 +58,6 @@ impl_parse! {
     SerdeStructAttr(input, out) {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.0.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
+        "default" => {},
     }
 }


### PR DESCRIPTION
This fixes some noise when using `ts-rs` with serde's `default` attribute. 

Without this change to the field and struct macros you will see the following when running `cargo test`:

```
warning: failed to parse serde attribute
  | 
  | #[serde(default)]
  | 
  = note: ts-rs failed to parse this attribute. It will be ignored.
warning: failed to parse serde attribute
  | 
  | #[serde(default, skip_serializing_if = "Option::is_none")]
  | 
  = note: ts-rs failed to parse this attribute. It will be ignored.
```