### PR TITLE
export_to supports output to directories

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -47,10 +47,16 @@ impl DerivedTS {
     }
 
     fn into_impl(self, rust_ty: Ident, generics: Generics) -> TokenStream {
-        let export_to = self
-            .export_to
-            .clone()
-            .unwrap_or_else(|| format!("bindings/{}.ts", self.name));
+        let export_to = match &self.export_to {
+            Some(dirname) if dirname.ends_with('/') => {
+                format!("{}{}.ts", dirname, self.name)
+            }
+            Some(filename) => filename.clone(),
+            None => {
+                format!("bindings/{}.ts", self.name)
+            }
+        };
+
         let export = match self.export {
             true => Some(self.generate_export_test(&rust_ty, &generics)),
             false => None,

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -12,6 +12,14 @@ struct User {
     active: bool,
 }
 
+#[derive(TS)]
+#[ts(export_to = "export_here_dir_test/")]
+struct UserDir {
+    name: String,
+    age: i32,
+    active: bool,
+}
+
 #[test]
 fn export_manually() {
     User::export().unwrap();
@@ -29,6 +37,27 @@ fn export_manually() {
     };
 
     let actual_content = fs::read_to_string("export_here_test.ts").unwrap();
+
+    assert_eq!(actual_content, expected_content);
+}
+
+#[test]
+fn export_manually_dir() {
+    UserDir::export().unwrap();
+
+    let expected_content = if cfg!(feature = "format") {
+        concat!(
+            "export interface UserDir {\n",
+            "  name: string;\n",
+            "  age: number;\n",
+            "  active: boolean;\n",
+            "}\n"
+        )
+    } else {
+        concat!("\nexport interface UserDir { name: string, age: number, active: boolean, }")
+    };
+
+    let actual_content = fs::read_to_string("export_here_dir_test/UserDir.ts").unwrap();
 
     assert_eq!(actual_content, expected_content);
 }


### PR DESCRIPTION
Related to discussion in #71.

Adds support for output to directories when the export_to path contains a trailing `/` character.