### PR TITLE
Disable Inflector default features

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,5 +18,5 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-Inflector = "0.11"
+Inflector = { version = "0.11", default-features = false }
 termcolor = { version = "1", optional = true }

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -28,7 +28,7 @@ chrono = { version = "0.4", features = ["serde"] }
 ts-rs-macros = { version = "6.1.0", path = "../macros" }
 dprint-plugin-typescript = { version = "0.43", optional = true }
 chrono = { version = "0.4.19", optional = true }
-bigdecimal = {version = ">=0.0.13, < 0.4.0", features = ["serde"], optional = true}
+bigdecimal = { version = ">=0.0.13, < 0.4.0", features = ["serde"], optional = true }
 uuid = { version = "0.8.2", optional = true }
 bytes = { version = "1.0", optional = true }
 thiserror = "1"


### PR DESCRIPTION
Removes regex and lazy_static from dependency tree.
---
Adds support for Result enum.