### PR TITLE
Remove `(default)` from `format` feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 - `serde-compat` (default)
 
   Enable serde compatibility. See below for more info.
-- `format` (default)
+- `format`
 
   When enabled, the generated typescript will be formatted.
   Currently, this sadly adds quite a bit of dependencies.


### PR DESCRIPTION
It is not default!