### PR TITLE
feat: add support for bson-uuid

### DIFF
--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -15,6 +15,7 @@ readme = "../README.md"
 chrono-impl = ["chrono"]
 bigdecimal-impl = ["bigdecimal"]
 uuid-impl = ["uuid"]
+bson-uuid-impl = ["bson"]
 bytes-impl = ["bytes"]
 serde-compat = ["ts-rs-macros/serde-compat"]
 format = ["dprint-plugin-typescript"]
@@ -31,6 +32,7 @@ dprint-plugin-typescript = { version = "0.43", optional = true }
 chrono = { version = "0.4.19", optional = true }
 bigdecimal = { version = ">=0.0.13, < 0.4.0", features = ["serde"], optional = true }
 uuid = { version = "0.8.2", optional = true }
+bson = { version = "2.2.0", optional = true, features = ["uuid-0_8"], default-features = false }
 bytes = { version = "1.0", optional = true }
 thiserror = "1"
 indexmap = { version = "1.6.1", optional = true }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -520,6 +520,9 @@ impl_primitives! { bigdecimal::BigDecimal => "string" }
 #[cfg(feature = "uuid-impl")]
 impl_primitives! { uuid::Uuid => "string" }
 
+#[cfg(feature = "bson-uuid-impl")]
+impl_primitives! { bson::Uuid => "string" }
+
 #[cfg(feature = "indexmap-impl")]
 impl_shadow!(as Vec<T>: impl<T: TS> TS for indexmap::IndexSet<T>);
 


### PR DESCRIPTION
This PR adds support for `bson::Uuid`, which is a wrapper around `uuid::Uuid`, and thus basically shares the same property. We use `bson::Uuid` for interacting with mongodb.