### PR TITLE
Implement ordered-float support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 - serde compatibility
 - generic types
 
+### limitations
+- generic fields cannot be inlined or flattened (#56)
+- type aliases must not alias generic types (#70)
+
 ### cargo features
 - `serde-compat` (default)
 
@@ -93,6 +97,10 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 - `indexmap-impl`
 
   Implement `TS` for `IndexMap` and `IndexSet` from indexmap
+
+- `ordered-float-impl`
+
+  Implement `TS` for `OrderedFloat` from ordered_float
 
 If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -21,6 +21,7 @@ serde-compat = ["ts-rs-macros/serde-compat"]
 format = ["dprint-plugin-typescript"]
 default = ["serde-compat"]
 indexmap-impl = ["indexmap"]
+ordered-float-impl = ["ordered-float"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -36,3 +37,4 @@ bson = { version = "2.2.0", optional = true, features = ["uuid-0_8"], default-fe
 bytes = { version = "1.0", optional = true }
 thiserror = "1"
 indexmap = { version = "1.6.1", optional = true }
+ordered-float = { version = "3.0.0", optional = true }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -96,6 +96,10 @@
 //!
 //!   Implement `TS` for `IndexMap` and `IndexSet` from indexmap  
 //!
+//! - `ordered-float-impl`
+//!
+//!   Implement `TS` for `OrderedFloat` from ordered_float
+//!
 //! If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 //!
 //! ## serde compatability
@@ -535,6 +539,12 @@ impl_primitives! { bigdecimal::BigDecimal => "string" }
 
 #[cfg(feature = "uuid-impl")]
 impl_primitives! { uuid::Uuid => "string" }
+
+#[cfg(feature = "ordered-float-impl")]
+impl_primitives! { ordered_float::OrderedFloat<f32> => "number" }
+
+#[cfg(feature = "ordered-float-impl")]
+impl_primitives! { ordered_float::OrderedFloat<f64> => "number" }
 
 #[cfg(feature = "bson-uuid-impl")]
 impl_primitives! { bson::Uuid => "string" }


### PR DESCRIPTION
Adds support for the ordered-float crate with a new "ordered-float-impl"
feature.
