### PR TITLE
Wrap invalid field names in quotes

### DIFF
--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -6,7 +6,7 @@ use crate::{
     attr::{FieldAttr, Inflection, StructAttr},
     deps::Dependencies,
     types::generics::{format_generics, format_type},
-    utils::to_ts_ident,
+    utils::{raw_name_to_ts_field, to_ts_ident},
     DerivedTS,
 };
 
@@ -107,9 +107,10 @@ fn format_field(
         (None, Some(rn)) => rn.apply(&field_name),
         (None, None) => field_name,
     };
+    let valid_name = raw_name_to_ts_field(name);
 
     formatted_fields.push(quote! {
-        format!("{}{}: {},", #name, #optional_annotation, #formatted_ty)
+        format!("{}{}: {},", #valid_name, #optional_annotation, #formatted_ty)
     });
 
     Ok(())

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -55,6 +55,18 @@ pub fn to_ts_ident(ident: &Ident) -> String {
     }
 }
 
+/// Convert an arbitrary name to a valid Typescript field name.
+///
+/// If the name contains special characters it will be wrapped in quotes.
+pub fn raw_name_to_ts_field(value: String) -> String {
+    let has_invalid_chars = value.chars().any(|c| !c.is_alphanumeric());
+    if has_invalid_chars {
+        format!(r#""{value}""#)
+    } else {
+        value
+    }
+}
+
 /// Parse all `#[ts(..)]` attributes from the given slice.
 pub fn parse_attrs<'a, A>(attrs: &'a [Attribute]) -> Result<impl Iterator<Item = A>>
 where

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -9,7 +9,14 @@ struct Rename {
     b: i32,
 }
 
+#[derive(serde::Serialize, TS)]
+struct RenameSerdeSpecialChar {
+    #[serde(rename = "a/b")]
+    b: i32,
+}
+
 #[test]
 fn test() {
-    assert_eq!(Rename::inline(), "{ A: number, B: number, }")
+    assert_eq!(Rename::inline(), "{ A: number, B: number, }");
+    assert_eq!(RenameSerdeSpecialChar::inline(), r#"{ "a/b": number, }"#);
 }


### PR DESCRIPTION
If a struct field name would be an invalid Typescript ident,
the field name is wrapped in quotes.
