### PR TITLE
Add feature to toggle export test codegen

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Aleph-Alpha/ts-rs"
 
 [features]
 serde-compat = ["termcolor"]
+test-export = []
 
 [lib]
 proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -58,7 +58,13 @@ impl DerivedTS {
         };
 
         let export = match self.export {
-            true => Some(self.generate_export_test(&rust_ty, &generics)),
+            true => {
+                if cfg!(feature = "test-export") {
+                    Some(self.generate_export_test(&rust_ty, &generics))
+                } else {
+                    None
+                }
+            }
             false => None,
         };
 

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["development-tools::ffi", "development-tools::build-utils", "wasm"
 readme = "../README.md"
 
 [features]
+# If enabled, each derived type will be exported in an automaticaly generated test.
+# On by default!
+test-export = ["ts-rs-macros/test-export"]
+
 chrono-impl = ["chrono"]
 bigdecimal-impl = ["bigdecimal"]
 uuid-impl = ["uuid"]
@@ -19,7 +23,7 @@ bson-uuid-impl = ["bson"]
 bytes-impl = ["bytes"]
 serde-compat = ["ts-rs-macros/serde-compat"]
 format = ["dprint-plugin-typescript"]
-default = ["serde-compat"]
+default = ["serde-compat", "test-export"]
 indexmap-impl = ["indexmap"]
 
 [dev-dependencies]


### PR DESCRIPTION
Adds a new feature `text-export` that toggles the code generation of export
tests.

Feature is on by default.
