### PR TITLE
Support PhantomData wrapper type

### DIFF
--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -56,7 +56,7 @@ pub(crate) fn export_type_to_string<T: TS + ?Sized>() -> Result<String, ExportEr
         use dprint_plugin_typescript::{configuration::ConfigurationBuilder, format_text};
 
         let fmt_cfg = ConfigurationBuilder::new().deno().build();
-        buffer = format_text(path.as_ref(), &buffer, &fmt_cfg).map_err(Formatting)?;
+        buffer = format_text(&Path::new(&"generated.ts"), &buffer, &fmt_cfg).map_err(Formatting)?;
     }
 
     Ok(buffer)

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -531,6 +531,7 @@ impl_wrapper!(impl<T: TS> TS for std::cell::Cell<T>);
 impl_wrapper!(impl<T: TS> TS for std::cell::RefCell<T>);
 impl_wrapper!(impl<T: TS> TS for std::sync::Mutex<T>);
 impl_wrapper!(impl<T: TS> TS for std::sync::Weak<T>);
+impl_wrapper!(impl<T: TS> TS for std::marker::PhantomData<T>);
 
 impl_tuples!(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10);
 


### PR DESCRIPTION
This PR adds support for std::marker::PhantomData<T>.

Useful for situations where you might have some type information associated with a struct, but that's not actually part of the struct's data.

There's one problem with this currently, and that is that the TypeScript typings are generated as if the PhantomData contents could be read directly. Reading from the field should be blocked somehow, but I'm not really sure how to accomplish that in TypeScript while also conveniently being able to access the type information. 