### PR TITLE
Fix compilation errors when building with `format` feature

### DIFF
--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -56,7 +56,7 @@ pub(crate) fn export_type_to_string<T: TS + ?Sized>() -> Result<String, ExportEr
         use dprint_plugin_typescript::{configuration::ConfigurationBuilder, format_text};
 
         let fmt_cfg = ConfigurationBuilder::new().deno().build();
-        buffer = format_text(path.as_ref(), &buffer, &fmt_cfg).map_err(Formatting)?;
+        buffer = format_text(&Path::new(&"generated.ts"), &buffer, &fmt_cfg).map_err(Formatting)?;
     }
 
     Ok(buffer)


### PR DESCRIPTION
The `path` variable is not available in this function (anymore?), and as such compilation will fail. Fix this by feeding a dummy path to `format_text()`. I'm not sure if there are any wider implications to this, but it seems to work in my testing.