### PR TITLE
Bumping uuid version 

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 ts-rs = { path = "../ts-rs", features = ["serde-compat", "uuid-impl"] }
 serde = { version = "1", features = ["derive", "rc"] }
 chrono = { version = "0.4", features = ["serde"] }
-uuid = { version = "0.8.2", features = ["v4", "serde"] }
+uuid = { version = "1.1.2", features = ["v4", "serde"] }

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -32,8 +32,8 @@ ts-rs-macros = { version = "6.2.0", path = "../macros" }
 dprint-plugin-typescript = { version = "0.43", optional = true }
 chrono = { version = "0.4.19", optional = true }
 bigdecimal = { version = ">=0.0.13, < 0.4.0", features = ["serde"], optional = true }
-uuid = { version = "0.8.2", optional = true }
-bson = { version = "2.2.0", optional = true, features = ["uuid-0_8"], default-features = false }
+uuid = { version = "^1.1.2", optional = true }
+bson = { version = "^2.2.0", optional = true }
 bytes = { version = "1.0", optional = true }
 thiserror = "1"
 indexmap = { version = "1.6.1", optional = true }


### PR DESCRIPTION
And removing feature flag from bson to use version 0.8 from uuid

Those changes are due to uuid crate releasing a 1.0 stable version.