### PR TITLE
Implement `char` as a primitive

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -575,7 +575,7 @@ impl_primitives! {
     u8, i8, u16, i16, u32, i32, f32, f64, usize, isize => "number",
     u64, i64, u128, i128 => "bigint",
     bool => "boolean",
-    Path, PathBuf, String, &'static str => "string",
+    char, Path, PathBuf, String, &'static str => "string",
     () => "null"
 }
 #[rustfmt::skip]

--- a/ts-rs/tests/simple.rs
+++ b/ts-rs/tests/simple.rs
@@ -11,12 +11,14 @@ struct Simple {
     c: (i32, String, RefCell<i32>),
     d: Vec<String>,
     e: Option<String>,
+    f: char,
+    g: Option<char>,
 }
 
 #[test]
 fn test_def() {
     assert_eq!(
         Simple::inline(),
-        "{ a: number, b: string, c: [number, string, number], d: Array<string>, e: string | null, }"
+        "{ a: number, b: string, c: [number, string, number], d: Array<string>, e: string | null, f: string, g: string | null, }"
     )
 }


### PR DESCRIPTION
Not much to see here, just added `char` as a primitive binding to `string`.