### PR TITLE
Support kebab-case rename

### DIFF
--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -20,6 +20,7 @@ pub enum Inflection {
     Snake,
     Pascal,
     ScreamingSnake,
+    Kebab,
 }
 
 impl Inflection {
@@ -33,6 +34,7 @@ impl Inflection {
             Inflection::Snake => string.to_snake_case(),
             Inflection::Pascal => string.to_pascal_case(),
             Inflection::ScreamingSnake => string.to_screaming_snake_case(),
+            Inflection::Kebab => string.to_kebab_case(),
         }
     }
 }
@@ -41,15 +43,18 @@ impl TryFrom<String> for Inflection {
     type Error = Error;
 
     fn try_from(value: String) -> Result<Self> {
-        Ok(match &*value.to_lowercase().replace("_", "") {
-            "lowercase" => Self::Lower,
-            "uppercase" => Self::Upper,
-            "camelcase" => Self::Camel,
-            "snakecase" => Self::Snake,
-            "pascalcase" => Self::Pascal,
-            "screamingsnakecase" => Self::ScreamingSnake,
-            _ => syn_err!("invalid inflection: '{}'", value),
-        })
+        Ok(
+            match &*value.to_lowercase().replace("_", "").replace("-", "") {
+                "lowercase" => Self::Lower,
+                "uppercase" => Self::Upper,
+                "camelcase" => Self::Camel,
+                "snakecase" => Self::Snake,
+                "pascalcase" => Self::Pascal,
+                "screamingsnakecase" => Self::ScreamingSnake,
+                "kebabcase" => Self::Kebab,
+                _ => syn_err!("invalid inflection: '{}'", value),
+            },
+        )
     }
 }
 

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -181,7 +181,7 @@ mod export;
 ///
 /// - `#[ts(rename_all = "..")]`:  
 ///   Rename all fields/variants of the type.
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
 ///
 ///
 /// ### struct field attributes
@@ -221,7 +221,7 @@ mod export;
 ///
 /// - `#[ts(rename_all = "..")]`:  
 ///   Rename all variants of this enum.  
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
 ///  
 /// ### enum variant attributes
 ///


### PR DESCRIPTION
According to serde document, the possible values for `rename_all` are "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE".

This crate now supports the first six variants, but `kebab-case` is not one of them. So this PR adds it to the list.

Unfortunately, `SCREAMING-KEBAB-CASE` is not supported by the Inflector crate. So I leave it as is.