### PR TITLE
Hackily support non-'static lifetimes

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -17,6 +17,6 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "1", features = ["full", "extra-traits"] }
+syn = { version = "1", features = ["full", "extra-traits", "visit-mut"] }
 Inflector = { version = "0.11", default-features = false }
 termcolor = { version = "1", optional = true }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -131,7 +131,7 @@ fn generate_impl(ty: &Ident, generics: &Generics) -> TokenStream {
     });
     let type_args = generics.params.iter().map(|param| match param {
         Type(TypeParam { ident, .. }) | Const(ConstParam { ident, .. }) => quote!(#ident),
-        Lifetime(LifetimeDef { .. }) => quote!( 'static ),
+        Lifetime(LifetimeDef { .. }) => quote!('static),
     });
 
     let where_bound = add_ts_to_where_clause(generics);

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -46,9 +46,19 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
                         .as_ref()
                         .map(|_| syn::parse2(quote!('static)).unwrap());
                 }
-                _ => syn::visit_mut::visit_type_mut(self, ty),
+                _ => {}
             }
             syn::visit_mut::visit_type_mut(self, ty);
+        }
+
+        fn visit_generic_argument_mut(&mut self, ga: &mut GenericArgument) {
+            match ga {
+                GenericArgument::Lifetime(lt) => {
+                    *lt = syn::parse2(quote!('static)).unwrap();
+                }
+                _ => {}
+            }
+            syn::visit_mut::visit_generic_argument_mut(self, ga);
         }
     }
     use syn::visit_mut::VisitMut;

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -38,17 +38,17 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
     // Remap all lifetimes to 'static in ty.
     struct Visitor;
     impl syn::visit_mut::VisitMut for Visitor {
-        fn visit_type_mut(&mut self, i: &mut Type) {
-            match i {
+        fn visit_type_mut(&mut self, ty: &mut Type) {
+            match ty {
                 Type::Reference(ref_type) => {
                     ref_type.lifetime = ref_type
                         .lifetime
                         .as_ref()
                         .map(|_| syn::parse2(quote!('static)).unwrap());
                 }
-                _ => syn::visit_mut::visit_type_mut(self, i),
+                _ => syn::visit_mut::visit_type_mut(self, ty),
             }
-            syn::visit_mut::visit_type_mut(self, i);
+            syn::visit_mut::visit_type_mut(self, ty);
         }
     }
     use syn::visit_mut::VisitMut;

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -37,6 +37,7 @@ pub(crate) fn named(
 
     let fields = quote!(vec![#(#formatted_fields),*].join(" "));
     let generic_args = format_generics(&mut dependencies, generics);
+
     Ok(DerivedTS {
         inline: quote! {
             format!(

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -37,7 +37,6 @@ pub(crate) fn named(
 
     let fields = quote!(vec![#(#formatted_fields),*].join(" "));
     let generic_args = format_generics(&mut dependencies, generics);
-
     Ok(DerivedTS {
         inline: quote! {
             format!(

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -221,3 +221,17 @@ fn nonstatic_lifetimes() {
     }
     assert_eq!(A::decl(), "interface A<> { t: string, }");
 }
+
+#[test]
+fn nonstatic_lifetimes_with_child() {
+    #[derive(TS)]
+    struct A<'a> {
+        t: &'a str,
+    }
+
+    #[derive(TS)]
+    struct B<'a> {
+        t: A<'a>,
+    }
+    assert_eq!(B::decl(), "interface B<> { t: A, }");
+}

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -212,3 +212,12 @@ fn trait_bounds() {
 
     assert_eq!(D::<&str, 41>::decl(), "interface D<T> { t: Array<T>, }")
 }
+
+#[test]
+fn nonstatic_lifetimes() {
+    #[derive(TS)]
+    struct A<'a> {
+        t: &'a str,
+    }
+    assert_eq!(A::decl(), "interface A<> { t: string, }");
+}


### PR DESCRIPTION
This is a hacky attempt to make ts-rs support non-`'static` lifetimes by simply dropping the quantification over lifetimes in our `impl`s of `TS`, and remapping every lifetime referenced inside of the `impl` to be `'static`. This PR seems to pass the tests, but I'll admit that I just hacked this together in a couple hours without carefully looking over ts-rs, so I have no idea if it breaks everything. Almost certainly this deserves more careful scrutiny by somebody who didn't just come to ts-rs's source for the first time today.

Here is an example struct that didn't work before, but works now:
```
#[derive(ts_rs::TS)]
#[ts(export)]
struct Foo<'a> {
    field: &'a str,
}
```

(This correctly exports to `export interface Foo<> { field: string, }`.)