### PR TITLE
feat: reimplement #[type = ..] on enums for `enum` generation

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -11,9 +11,10 @@ pub struct EnumAttr {
     pub rename: Option<String>,
     pub export_to: Option<String>,
     pub export: bool,
-    tag: Option<String>,
-    untagged: bool,
-    content: Option<String>,
+    pub r#type: Option<String>,
+    pub tag: Option<String>,
+    pub untagged: bool,
+    pub content: Option<String>,
 }
 
 #[cfg(feature = "serde-compat")]
@@ -59,6 +60,7 @@ impl EnumAttr {
             untagged,
             export_to,
             export,
+            r#type,
         }: EnumAttr,
     ) {
         self.rename = self.rename.take().or(rename);
@@ -68,6 +70,7 @@ impl EnumAttr {
         self.content = self.content.take().or(content);
         self.export = self.export || export;
         self.export_to = self.export_to.take().or(export_to);
+        self.r#type = self.r#type.take().or(r#type);
     }
 }
 
@@ -76,7 +79,8 @@ impl_parse! {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
         "export_to" => out.export_to = Some(parse_assign_str(input)?),
-        "export" => out.export = true
+        "export" => out.export = true,
+        "type" => out.r#type = Some(parse_assign_str(input)?)
     }
 }
 
@@ -87,6 +91,7 @@ impl_parse! {
         "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "tag" => out.0.tag = Some(parse_assign_str(input)?),
         "content" => out.0.content = Some(parse_assign_str(input)?),
-        "untagged" => out.0.untagged = true
+        "untagged" => out.0.untagged = true,
+        "type" => out.0.r#type = Some(parse_assign_str(input)?)
     }
 }

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::{Fields, Generics, ItemEnum, Variant};
 
 use crate::{
@@ -16,6 +16,15 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
     let name = match &enum_attr.rename {
         Some(existing) => existing.clone(),
         None => s.ident.to_string(),
+    };
+
+    let is_enum = match enum_attr.r#type.as_deref() {
+        Some("enum" | "const enum") => true,
+        None | Some("type") => false,
+        Some(x) => syn_err!(
+            "Either `const enum`, `enum` or `type` is accepted; was: {:?}",
+            x
+        ),
     };
 
     if s.variants.is_empty() {
@@ -36,26 +45,125 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
 
     let mut formatted_variants = vec![];
     let mut dependencies = Dependencies::default();
-    for variant in &s.variants {
-        format_variant(
-            &mut formatted_variants,
-            &mut dependencies,
-            &enum_attr,
-            variant,
-            &s.generics,
-        )?;
+
+    if is_enum {
+        let any_renamed = enum_attr.rename_all.is_some()
+            || s.variants
+                .iter()
+                .find(|v| {
+                    let FieldAttr { rename, .. } = FieldAttr::from_attrs(&v.attrs).unwrap();
+                    rename.is_some()
+                })
+                .is_some();
+
+        for variant in &s.variants {
+            format_enum_variant(&mut formatted_variants, &enum_attr, &variant, any_renamed)?;
+        }
+    } else {
+        for variant in &s.variants {
+            format_variant(
+                &mut formatted_variants,
+                &mut dependencies,
+                &enum_attr,
+                variant,
+                &s.generics,
+            )?;
+        }
     }
 
+    let inline = if is_enum {
+        quote!([#(#formatted_variants),*].join(", "))
+    } else {
+        quote!([#(#formatted_variants),*].join(" | "))
+    };
+
+    let overwrite_type = enum_attr.r#type.unwrap_or(String::from("type"));
+
     let generic_args = format_generics(&mut dependencies, &s.generics);
+    let decl = if is_enum {
+        quote!(format!("{} {}{} {{{}}}", #overwrite_type, #name, #generic_args, Self::inline()))
+    } else {
+        quote!(format!("{} {}{} = {};", #overwrite_type, #name, #generic_args, Self::inline()))
+    };
+
     Ok(DerivedTS {
-        inline: quote!(vec![#(#formatted_variants),*].join(" | ")),
-        decl: quote!(format!("type {}{} = {};", #name, #generic_args, Self::inline())),
+        inline,
+        decl,
         inline_flattened: None,
         dependencies,
         name,
         export: enum_attr.export,
         export_to: enum_attr.export_to,
     })
+}
+
+/// If any have been renamed then we want to rename all enum variants
+fn format_enum_variant(
+    formatted_variants: &mut Vec<TokenStream>,
+    enum_attr: &EnumAttr,
+    variant: &Variant,
+    any_renamed: bool,
+) -> syn::Result<()> {
+    let FieldAttr {
+        type_override,
+        rename,
+        inline,
+        skip,
+        flatten,
+        optional,
+    } = FieldAttr::from_attrs(&variant.attrs)?;
+
+    match (skip, &type_override, inline, flatten, optional) {
+        (true, ..) => return Ok(()),
+        (_, Some(_), ..) => syn_err!("`type_override` is not applicable to enum variants"),
+        (_, _, _, true, _) => syn_err!("`flatten` is not applicable to enum variants"),
+        (_, _, true, _, _) => {
+            syn_err!("`inline` is not applicable to enum variants when type enum")
+        }
+        _ => {}
+    };
+
+    let name = variant.ident.to_string();
+
+    let enum_renamed_value: Option<String> = match (rename, &enum_attr.rename_all, any_renamed) {
+        (Some(rn), _, _) => Some(rn),
+        (None, None, true) => Some(name.clone()),
+        (None, None, false) => None,
+        (None, Some(rn), _) => Some(rn.apply(&name)),
+    };
+
+    for (forbidden_attr_name, forbidden_attr_val) in [
+        ("tag", &enum_attr.tag.as_deref()),
+        ("content", &enum_attr.content.as_deref()),
+        ("untagged", &enum_attr.untagged.then(|| "true")),
+    ] {
+        if let Some(_) = forbidden_attr_val {
+            syn_err!(
+                "Invalid enum attribute {:?} when type is enum.",
+                forbidden_attr_name
+            )
+        }
+    }
+
+    formatted_variants.push(if let Some((_, expr)) = &variant.discriminant {
+        let str = format!("{}={}", name, expr.to_token_stream());
+        quote!(#str)
+    } else if let Some(renamed) = enum_renamed_value {
+        if let Some((_, e)) = &variant.discriminant {
+            if !any_renamed {
+                syn_err!(
+                    "{:?} Can't be both renamed and have a discriminant {:?}",
+                    name,
+                    e.to_token_stream()
+                );
+            }
+        }
+        let str = format!("{}=\"{}\"", name, renamed);
+        quote!(#str)
+    } else {
+        quote!(#name)
+    });
+    Ok(())
 }
 
 fn format_variant(

--- a/ts-rs/tests/rename_enum_type.rs
+++ b/ts-rs/tests/rename_enum_type.rs
@@ -1,11 +1,10 @@
 #![allow(dead_code)]
-use serde::Deserialize;
 use ts_rs::TS;
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "const enum")]
 enum SimpleConstEnum {
-    #[serde(rename = "a")]
+    #[ts(rename = "a")]
     A,
     B,
 }
@@ -18,7 +17,7 @@ fn const_enum() {
     );
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "enum")]
 enum SimpleEnum {
     A,
@@ -30,11 +29,11 @@ fn simple_enum() {
     assert_eq!(SimpleEnum::decl(), r#"enum SimpleEnum {A, B}"#);
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "enum")]
 enum EnumWithBothNumberAndARename {
     A = 1,
-    #[serde(rename = "XD")]
+    #[ts(rename = "XD")]
     B,
 }
 
@@ -46,7 +45,7 @@ fn enum_with_both_number_and_rename() {
     );
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "enum")]
 enum SimpleEnumWithNumberAssigned {
     A = 1,
@@ -61,10 +60,10 @@ fn simple_enum_discriminant() {
     )
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "enum")]
 enum SimpleEnumWithRename {
-    #[serde(rename = "a")]
+    #[ts(rename = "a")]
     A,
     B,
 }
@@ -77,11 +76,11 @@ fn simple_enum_variant_rename() {
     );
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 #[ts(type = "enum")]
-#[serde(rename_all = "lowercase")]
+#[ts(rename_all = "lowercase")]
 enum SimpleEnumWithInflection {
-    #[serde(rename = "a")]
+    #[ts(rename = "a")]
     A,
     B,
 }
@@ -94,10 +93,10 @@ fn simple_enum_inflection() {
     );
 }
 
-#[derive(TS, Deserialize)]
+#[derive(TS)]
 // #[ts(type="type")]
 enum SimpleEnumNotChanged {
-    #[serde(rename = "a")]
+    #[ts(rename = "a")]
     A,
     B,
 }

--- a/ts-rs/tests/rename_enum_type.rs
+++ b/ts-rs/tests/rename_enum_type.rs
@@ -1,0 +1,111 @@
+#![allow(dead_code)]
+use serde::Deserialize;
+use ts_rs::TS;
+
+#[derive(TS, Deserialize)]
+#[ts(type = "const enum")]
+enum SimpleConstEnum {
+    #[serde(rename = "a")]
+    A,
+    B,
+}
+
+#[test]
+fn const_enum() {
+    assert_eq!(
+        SimpleConstEnum::decl(),
+        r#"const enum SimpleConstEnum {A="a", B="B"}"#
+    );
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type = "enum")]
+enum SimpleEnum {
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum() {
+    assert_eq!(SimpleEnum::decl(), r#"enum SimpleEnum {A, B}"#);
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type = "enum")]
+enum EnumWithBothNumberAndARename {
+    A = 1,
+    #[serde(rename = "XD")]
+    B,
+}
+
+#[test]
+fn enum_with_both_number_and_rename() {
+    assert_eq!(
+        EnumWithBothNumberAndARename::decl(),
+        r#"enum EnumWithBothNumberAndARename {A=1, B="XD"}"#
+    );
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type = "enum")]
+enum SimpleEnumWithNumberAssigned {
+    A = 1,
+    B,
+}
+
+#[test]
+fn simple_enum_discriminant() {
+    assert_eq!(
+        SimpleEnumWithNumberAssigned::decl(),
+        r#"enum SimpleEnumWithNumberAssigned {A=1, B}"#
+    )
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type = "enum")]
+enum SimpleEnumWithRename {
+    #[serde(rename = "a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_variant_rename() {
+    assert_eq!(
+        SimpleEnumWithRename::decl(),
+        r#"enum SimpleEnumWithRename {A="a", B="B"}"#
+    );
+}
+
+#[derive(TS, Deserialize)]
+#[ts(type = "enum")]
+#[serde(rename_all = "lowercase")]
+enum SimpleEnumWithInflection {
+    #[serde(rename = "a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_inflection() {
+    assert_eq!(
+        SimpleEnumWithInflection::decl(),
+        r#"enum SimpleEnumWithInflection {A="a", B="b"}"#
+    );
+}
+
+#[derive(TS, Deserialize)]
+// #[ts(type="type")]
+enum SimpleEnumNotChanged {
+    #[serde(rename = "a")]
+    A,
+    B,
+}
+
+#[test]
+fn simple_enum_not_changed() {
+    assert_eq!(
+        SimpleEnumNotChanged::decl(),
+        r#"type SimpleEnumNotChanged = "a" | "B";"#
+    );
+}


### PR DESCRIPTION
This is a reimplementation of #24. I tried merging that PR into main but I had some merge issues because the PR is old. 
All the tests pass and you can now add `#[ts(type = "enum"]` or `#[ts(type = "const enum"]` to generate an enum like 
```rust
#[ts(type = "const enum")]
enum Dog {
  Woof,
  Bark,
  Howl
}
```
generates a typescript enum like 
```typescript
const enum Dog = { Woof, Bark, Howl };
```
Credits to @JakubKoralewski for implementing this.