### PR TITLE
TypeGroup support in `extract_type_args`

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -1,6 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeTuple};
+use syn::{
+    GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeGroup, TypeTuple,
+};
 
 use crate::{attr::StructAttr, deps::Dependencies};
 
@@ -96,6 +98,7 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
 
 fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
     let last_segment = match ty {
+        Type::Group(TypeGroup { elem, .. }) => return extract_type_args(elem),
         Type::Path(type_path) => type_path.path.segments.last(),
         _ => None,
     }?;

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -39,8 +39,29 @@ struct Container {
     baz: Box<BTreeMap<String, Rc<Generic<String>>>>,
 }
 
+macro_rules! declare {
+    ($(#[$meta:meta])* $name:ident { $($fident:ident: $t:ty),+ $(,)? }) => {
+        $(#[$meta])*
+        struct $name {
+            $(pub $fident: $t),+
+        }
+    }
+}
+
+declare! {
+    #[derive(TS)]
+    TypeGroup {
+        foo: Vec<Container>,
+    }
+}
+
 #[test]
 fn test() {
+    assert_eq!(
+        TypeGroup::decl(),
+        "interface TypeGroup { foo: Array<Container>, }",
+    );
+
     assert_eq!(
         Generic::<()>::decl(),
         "interface Generic<T> { value: T, values: Array<T>, }"


### PR DESCRIPTION
The issue this PR fixes:

It turns out that field type is wrapped into a `Type::Group` in some cases (e.g when struct definition is generated via macro) and `extract_type_args` is unable to properly extract types.