### PR TITLE
Suppress warnings feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We recommend doing this in your tests.
 ### get started
 ```toml
 [dependencies]
-ts-rs = "6.2"
+ts-rs = "6.1"
 ```
 
 ```rust
@@ -102,6 +102,10 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 
   Implement `TS` for `OrderedFloat` from ordered_float
 
+- `suppress-warnings`
+
+  Suppress compile-time messages for unknown serde annotations
+
 If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 
 ### serde compatability
@@ -119,7 +123,7 @@ Supported serde attributes:
 - `flatten`
 - `default`
 
-When ts-rs encounters an unsupported serde attribute, a warning is emitted.
+When ts-rs encounters an unsupported serde attribute, a warning is emitted unless the `suppress-warnings` feature is enabled.
 
 ### contributing
 Contributions are always welcome!

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Aleph-Alpha/ts-rs"
 
 [features]
 serde-compat = ["termcolor"]
+suppress-warnings = []
 
 [lib]
 proc-macro = true

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -126,6 +126,10 @@ mod warning {
         content: impl Display,
         note: impl Display,
     ) -> std::io::Result<()> {
+        if cfg!(feature = "suppress-warnings") {
+            return Ok(());
+        }
+
         let make_color = |color: Color, bold: bool| {
             let mut spec = ColorSpec::new();
             spec.set_fg(Some(color)).set_bold(bold).set_intense(true);

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -22,6 +22,7 @@ format = ["dprint-plugin-typescript"]
 default = ["serde-compat"]
 indexmap-impl = ["indexmap"]
 ordered-float-impl = ["ordered-float"]
+suppress-warnings = ["ts-rs-macros/suppress-warnings"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -99,6 +99,10 @@
 //! - `ordered-float-impl`
 //!
 //!   Implement `TS` for `OrderedFloat` from ordered_float
+//! 
+//! - `suppress-warnings`
+//! 
+//!   Suppress compile-time messages for unknown serde annotations
 //!
 //! If there's a type you're dealing with which doesn't implement `TS`, use `#[ts(type = "..")]` or open a PR.
 //!
@@ -117,7 +121,7 @@
 //! - `flatten`
 //! - `default`
 //!
-//! When ts-rs encounters an unsupported serde attribute, a warning is emitted.
+//! When ts-rs encounters an unsupported serde attribute, a warning is emitted unless the `suppress-warnings` feature is enabled.
 //!
 //! ## contributing
 //! Contributions are always welcome!


### PR DESCRIPTION
Install non-default feature "suppress-warnings" to suppress all the compile-time messages about ts-rs being unable to parse serde annotations.