### PR TITLE
Fix type struct with zero fields

### DIFF
--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -26,11 +26,11 @@ fn type_def(
     let name = attr.rename.clone().unwrap_or_else(|| to_ts_ident(ident));
     match fields {
         Fields::Named(named) => match named.named.len() {
-            0 => unit::unit(attr, &name),
+            // 0 => unit::unit(attr, &name),
             _ => named::named(attr, &name, named, generics),
         },
         Fields::Unnamed(unnamed) => match unnamed.unnamed.len() {
-            0 => unit::unit(attr, &name),
+            // 0 => unit::unit(attr, &name),
             1 => newtype::newtype(attr, &name, unnamed, generics),
             _ => tuple::tuple(attr, &name, unnamed, generics),
         },

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -35,7 +35,7 @@ pub(crate) fn named(
         )?;
     }
 
-    let fields = quote!(vec![#(#formatted_fields),*].join(" "));
+    let fields = quote!((vec![#(#formatted_fields),*] as Vec<String>).join(" "));
     let generic_args = format_generics(&mut dependencies, generics);
 
     Ok(DerivedTS {


### PR DESCRIPTION
types of `struct Foo();` and `struct Foo{}` are incorrect. Type should be `[]` and `{}` for compat with serde json.

This is just a simple patch, I will cleanup it up and fix the tests if approved.