### PR TITLE
Add doc note about the necessity to use `export`

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -180,6 +180,7 @@ mod export;
 /// - `#[ts(export_to = "..")]`:  
 ///   Specifies where the type should be exported to. Defaults to `bindings/<name>.ts`.  
 ///   If the provided path ends in a trailing `/`, it is interpreted as a directory.   
+///   Note that you need to add the `export` attribute as well, in order to generate a test which exports the type.
 ///
 /// - `#[ts(rename = "..")]`:  
 ///   Sets the typescript name of the generated type


### PR DESCRIPTION
We found ourselves not being able to export to a specific directory today. We found the answer to the problem in this issue: https://github.com/Aleph-Alpha/ts-rs/issues/105#issuecomment-1140435797 Figured it would be a good idea to make a note of this for future users.