### PR TITLE
Don't warn about `#[serde(with = "...")]`

### DIFF
--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -74,5 +74,9 @@ impl_parse! {
                 parse_assign_str(input)?;
             }
         },
+        // parse #[serde(with = "...")] to not emit a warning
+        "with" => {
+            parse_assign_str(input)?;
+        },
     }
 }


### PR DESCRIPTION
I had some code like this:

```rs
use chrono::serde::ts_seconds;
use chrono::DateTime;
use serde::{Deserialize, Serialize};
use ts_rs::TS;

#[derive(Serialize, Deserialize, TS)]
#[ts(export)]
pub struct Test {
    #[ts(type = "number")]
    #[serde(with = "ts_seconds")]
    some_time: DateTime<Utc>,
}
```

ts-rs already handles this perfectly, as long as `number` really is the type that `ts_seconds` transforms the field to/from. However, it issues a warning about unrecognized attribute `#[serde(with)]`. So I wrote this patch that parses this attribute and silences the warning.