### PR TITLE
Fix useless_vec lints

### DIFF
--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -38,7 +38,7 @@ impl ToTokens for Dependencies {
         let dependencies = &self.0;
         tokens.extend(quote! {
             {
-                let mut dependencies = vec![];
+                let mut dependencies = Vec::new();
                 #( #dependencies )*
                 dependencies
             }

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -34,7 +34,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
         });
     }
 
-    let mut formatted_variants = vec![];
+    let mut formatted_variants = Vec::new();
     let mut dependencies = Dependencies::default();
     for variant in &s.variants {
         format_variant(
@@ -48,7 +48,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
 
     let generic_args = format_generics(&mut dependencies, &s.generics);
     Ok(DerivedTS {
-        inline: quote!(vec![#(#formatted_variants),*].join(" | ")),
+        inline: quote!([#(#formatted_variants),*].join(" | ")),
         decl: quote!(format!("type {}{} = {};", #name, #generic_args, Self::inline())),
         inline_flattened: None,
         dependencies,

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -29,7 +29,7 @@ pub fn format_generics(deps: &mut Dependencies, generics: &Generics) -> TokenStr
         _ => None,
     });
 
-    let comma_separated = quote!(vec![#(#expanded_params),*].join(", "));
+    let comma_separated = quote!([#(#expanded_params),*].join(", "));
     quote!(format!("<{}>", #comma_separated))
 }
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -16,7 +16,7 @@ pub(crate) fn named(
     fields: &FieldsNamed,
     generics: &Generics,
 ) -> Result<DerivedTS> {
-    let mut formatted_fields = vec![];
+    let mut formatted_fields = Vec::new();
     let mut dependencies = Dependencies::default();
     if let Some(tag) = &attr.tag {
         let formatted = format!("{}: \"{}\",", tag, name);
@@ -35,7 +35,7 @@ pub(crate) fn named(
         )?;
     }
 
-    let fields = quote!(vec![#(#formatted_fields),*].join(" "));
+    let fields = quote!([#(#formatted_fields),*].join(" "));
     let generic_args = format_generics(&mut dependencies, generics);
 
     Ok(DerivedTS {

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -33,7 +33,7 @@ pub(crate) fn tuple(
         inline: quote! {
             format!(
                 "[{}]",
-                vec![#(#formatted_fields),*].join(", ")
+                [#(#formatted_fields),*].join(", ")
             )
         },
         decl: quote! {

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -343,10 +343,10 @@ macro_rules! impl_tuples {
     ( impl $($i:ident),* ) => {
         impl<$($i: TS),*> TS for ($($i,)*) {
             fn name() -> String {
-                format!("[{}]", vec![$($i::name()),*].join(", "))
+                format!("[{}]", [$($i::name()),*].join(", "))
             }
             fn inline() -> String {
-                format!("[{}]", vec![ $($i::inline()),* ].join(", "))
+                format!("[{}]", [ $($i::inline()),* ].join(", "))
             }
             fn dependencies() -> Vec<Dependency> {
                 [$( Dependency::from_ty::<$i>() ),*]

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -70,20 +70,20 @@
 //! - type aliases must not alias generic types (#70)
 //!
 //! ## cargo features
-//! - `serde-compat` (default)  
+//! - `serde-compat` (default)
 //!
-//!   Enable serde compatibility. See below for more info.  
+//!   Enable serde compatibility. See below for more info.
 //! - `format`
 //!
 //!   When enabled, the generated typescript will be formatted.
 //!   Currently, this sadly adds quite a bit of dependencies.
-//! - `chrono-impl`  
+//! - `chrono-impl`
 //!
-//!   Implement `TS` for types from chrono  
-//! - `bigdecimal-impl`  
+//!   Implement `TS` for types from chrono
+//! - `bigdecimal-impl`
 //!
-//!   Implement `TS` for types from bigdecimal  
-//! - `uuid-impl`  
+//!   Implement `TS` for types from bigdecimal
+//! - `uuid-impl`
 //!
 //!   Implement `TS` for types from uuid
 //! - `bson-uuid-impl`
@@ -91,10 +91,10 @@
 //!   Implement `TS` for types from bson
 //! - `bytes-impl`
 //!
-//!   Implement `TS` for types from bytes    
-//! - `indexmap-impl`  
+//!   Implement `TS` for types from bytes
+//! - `indexmap-impl`
 //!
-//!   Implement `TS` for `IndexMap` and `IndexSet` from indexmap  
+//!   Implement `TS` for `IndexMap` and `IndexSet` from indexmap
 //!
 //! - `ordered-float-impl`
 //!
@@ -152,8 +152,8 @@ pub use crate::export::ExportError;
 mod chrono;
 mod export;
 
-/// A type which can be represented in TypeScript.  
-/// Most of the time, you'd want to derive this trait instead of implementing it manually.  
+/// A type which can be represented in TypeScript.
+/// Most of the time, you'd want to derive this trait instead of implementing it manually.
 /// ts-rs comes with implementations for all primitives, most collections, tuples,
 /// arrays and containers.
 ///
@@ -173,68 +173,68 @@ mod export;
 /// ### container attributes
 /// attributes applicable for both structs and enums
 ///
-/// - `#[ts(export)]`:  
+/// - `#[ts(export)]`:
 ///   Generates a test which will export the type, by default to `bindings/<name>.ts` when running
 ///   `cargo test`
 ///
-/// - `#[ts(export_to = "..")]`:  
-///   Specifies where the type should be exported to. Defaults to `bindings/<name>.ts`.  
-///   If the provided path ends in a trailing `/`, it is interpreted as a directory.   
+/// - `#[ts(export_to = "..")]`:
+///   Specifies where the type should be exported to. Defaults to `bindings/<name>.ts`.
+///   If the provided path ends in a trailing `/`, it is interpreted as a directory.
 ///
-/// - `#[ts(rename = "..")]`:  
+/// - `#[ts(rename = "..")]`:
 ///   Sets the typescript name of the generated type
 ///
-/// - `#[ts(rename_all = "..")]`:  
+/// - `#[ts(rename_all = "..")]`:
 ///   Rename all fields/variants of the type.
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
 ///
 ///
 /// ### struct field attributes
 ///
-/// - `#[ts(type = "..")]`:  
-///   Overrides the type used in TypeScript.  
-///   This is useful when there's a type for which you cannot derive `TS`.  
+/// - `#[ts(type = "..")]`:
+///   Overrides the type used in TypeScript.
+///   This is useful when there's a type for which you cannot derive `TS`.
 ///
-/// - `#[ts(rename = "..")]`:  
-///   Renames this field  
+/// - `#[ts(rename = "..")]`:
+///   Renames this field
 ///
-/// - `#[ts(inline)]`:  
-///   Inlines the type of this field  
+/// - `#[ts(inline)]`:
+///   Inlines the type of this field
 ///
-/// - `#[ts(skip)]`:  
-///   Skip this field  
+/// - `#[ts(skip)]`:
+///   Skip this field
 ///
-/// - `#[ts(optional)]`:  
+/// - `#[ts(optional)]`:
 ///   Indicates the field may be omitted from the serialized struct
 ///
-/// - `#[ts(flatten)]`:  
-///   Flatten this field (only works if the field is a struct)  
-///   
+/// - `#[ts(flatten)]`:
+///   Flatten this field (only works if the field is a struct)
+///
 /// ### enum attributes
 ///
-/// - `#[ts(tag = "..")]`:  
+/// - `#[ts(tag = "..")]`:
 ///   Changes the representation of the enum to store its tag in a separate field.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///
-/// - `#[ts(content = "..")]`:  
+/// - `#[ts(content = "..")]`:
 ///   Changes the representation of the enum to store its content in a separate field.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///
-/// - `#[ts(untagged)]`:  
+/// - `#[ts(untagged)]`:
 ///   Changes the representation of the enum to not include its tag.
 ///   See [the serde docs](https://serde.rs/enum-representations.html).
 ///
-/// - `#[ts(rename_all = "..")]`:  
-///   Rename all variants of this enum.  
+/// - `#[ts(rename_all = "..")]`:
+///   Rename all variants of this enum.
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
-///  
+///
 /// ### enum variant attributes
 ///
-/// - `#[ts(rename = "..")]`:  
-///   Renames this variant  
+/// - `#[ts(rename = "..")]`:
+///   Renames this variant
 ///
-/// - `#[ts(skip)]`:  
-///   Skip this variant  
+/// - `#[ts(skip)]`:
+///   Skip this variant
 pub trait TS: 'static {
     const EXPORT_TO: Option<&'static str> = None;
 
@@ -258,7 +258,7 @@ pub trait TS: 'static {
         panic!("{} cannot be inlined", Self::name());
     }
 
-    /// Flatten an type declaration.  
+    /// Flatten an type declaration.
     /// This function will panic if the type cannot be flattened.
     fn inline_flattened() -> String {
         panic!("{} cannot be flattened", Self::name())
@@ -268,7 +268,7 @@ pub trait TS: 'static {
     /// This is used for resolving imports when exporting to a file.
     fn dependencies() -> Vec<Dependency>;
 
-    /// `true` if this is a transparent type, e.g tuples or a list.  
+    /// `true` if this is a transparent type, e.g tuples or a list.
     /// This is used for resolving imports when using the `export!` macro.
     fn transparent() -> bool;
 
@@ -289,7 +289,7 @@ pub trait TS: 'static {
         export::export_type_to::<Self, _>(path)
     }
 
-    /// Manually generate bindings for this type, returning a [`String`].  
+    /// Manually generate bindings for this type, returning a [`String`].
     /// This function does not format the output, even if the `format` feature is enabled.
     fn export_to_string() -> Result<String, ExportError> {
         export::export_type_to_string::<Self>()


### PR DESCRIPTION
Resolves GH-158.

Beta clippy recently started failing on a downstream consumer ([issue](https://github.com/frog-pond/ccc-server-next/issues/83)) of this crate. This was because of a number of calls to `vec!` that were picked up by clippy. This lint only fires, at time of writing, in beta (stable does not have the change that introduced it, and nightly has since changed to ignore this lint in macros...), but I figured I might as well clean it up and take care of GH-158. This will, assuming this change gets released quickly, help my fellow `#![deny(clippy::all)]` folks who use this crate.

I've also removed some trailing whitespace in `ts-rs/src/lib.rs`. I did this in a separate commit, so d4dfefe can be reviewed on its own.