### PR TITLE
Check for empty tuple in `format_type`

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -71,6 +71,13 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
         // same goes for a tuple (`(A, B, C)`) - it doesn't have a type arg, so we handle it
         // explicitly here.
         Type::Tuple(tuple) => {
+            if tuple.elems.is_empty() {
+                // empty tuples `()` should be treated as `null`
+                return super::unit::null(&StructAttr::default(), "")
+                    .unwrap()
+                    .inline;
+            }
+
             // we convert the tuple field to a struct: `(A, B, C)` => `struct A(A, B, C)`
             let tuple_struct = super::type_def(
                 &StructAttr::default(),

--- a/ts-rs/tests/unit.rs
+++ b/ts-rs/tests/unit.rs
@@ -14,9 +14,14 @@ struct Unit2 {}
 #[derive(TS)]
 struct Unit3();
 
+// serde_json serializes this to `null`, so it's TS type is `null` as well.
+#[derive(TS)]
+struct Unit4(());
+
 #[test]
 fn test() {
     assert_eq!("type Unit = null;", Unit::decl());
     assert_eq!("type Unit2 = Record<string, never>;", Unit2::decl());
     assert_eq!("type Unit3 = never[];", Unit3::decl());
+    assert_eq!("type Unit4 = null;", Unit4::decl());
 }


### PR DESCRIPTION
Empty tuple fields `()` are currently identified as `never[]` but are serialized into `null`. This PR fixes this by checking for an empty tuple at `format_type`. This can come up in generics where `T = ()`.