### PR TITLE
Made the TS implementation for hashmap and hashset generic over all hashers

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -104,7 +104,7 @@
 //!   Implement `TS` for `OrderedFloat` from ordered_float
 //!
 //! - `heapless-impl`  
-//! 
+//!
 //!   Implement `TS` for `Vec` from heapless
 //!
 //!
@@ -490,7 +490,7 @@ impl<T: TS> TS for Vec<T> {
     }
 }
 
-impl<K: TS, V: TS> TS for HashMap<K, V> {
+impl<K: TS, V: TS, H> TS for HashMap<K, V, H> {
     fn name() -> String {
         "Record".to_owned()
     }
@@ -579,7 +579,7 @@ impl<I: TS> TS for RangeInclusive<I> {
 }
 
 impl_shadow!(as T: impl<'a, T: TS + ?Sized> TS for &T);
-impl_shadow!(as Vec<T>: impl<T: TS> TS for HashSet<T>);
+impl_shadow!(as Vec<T>: impl<T: TS, H> TS for HashSet<T, H>);
 impl_shadow!(as Vec<T>: impl<T: TS> TS for BTreeSet<T>);
 impl_shadow!(as HashMap<K, V>: impl<K: TS, V: TS> TS for BTreeMap<K, V>);
 impl_shadow!(as Vec<T>: impl<T: TS, const N: usize> TS for [T; N]);

--- a/ts-rs/tests/hashmap.rs
+++ b/ts-rs/tests/hashmap.rs
@@ -1,0 +1,37 @@
+use std::collections::{HashMap, HashSet};
+use ts_rs::TS;
+
+#[test]
+fn hashmap() {
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct Hashes {
+        map: HashMap<String, String>,
+        set: HashSet<String>,
+    }
+
+    assert_eq!(
+        Hashes::decl(),
+        "interface Hashes { map: Record<string, string>, set: Array<string>, }"
+    )
+}
+
+#[test]
+fn hashmap_with_custom_hasher() {
+    struct CustomHasher {}
+
+    type CustomHashMap<K, V> = HashMap<K, V, CustomHasher>;
+    type CustomHashSet<K> = HashSet<K, CustomHasher>;
+
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct Hashes {
+        map: CustomHashMap<String, String>,
+        set: CustomHashSet<String>,
+    }
+
+    assert_eq!(
+        Hashes::decl(),
+        "interface Hashes { map: Record<string, string>, set: Array<string>, }"
+    )
+}

--- a/ts-rs/tests/hashmap.rs
+++ b/ts-rs/tests/hashmap.rs
@@ -12,7 +12,7 @@ fn hashmap() {
 
     assert_eq!(
         Hashes::decl(),
-        "interface Hashes { map: Record<string, string>, set: Array<string>, }"
+        "type Hashes = { map: Record<string, string>, set: Array<string>, }"
     )
 }
 
@@ -32,6 +32,6 @@ fn hashmap_with_custom_hasher() {
 
     assert_eq!(
         Hashes::decl(),
-        "interface Hashes { map: Record<string, string>, set: Array<string>, }"
+        "type Hashes = { map: Record<string, string>, set: Array<string>, }"
     )
 }


### PR DESCRIPTION
By default the hasher is [RandomState](https://doc.rust-lang.org/stable/std/collections/hash_map/struct.RandomState.html) but developers can override this. This PR makes ts-rs usable with e.g. https://docs.rs/rustc-hash/latest/rustc_hash/.

