### PR TITLE
fix: Include borrowed types' type arguments in typescript

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -1,7 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeGroup, TypeTuple,
+    GenericArgument, GenericParam, Generics, ItemStruct, PathArguments, Type, TypeGroup,
+    TypeReference, TypeTuple,
 };
 
 use crate::{attr::StructAttr, deps::Dependencies};
@@ -109,7 +110,9 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
 
 fn extract_type_args(ty: &Type) -> Option<Vec<&Type>> {
     let last_segment = match ty {
-        Type::Group(TypeGroup { elem, .. }) => return extract_type_args(elem),
+        Type::Group(TypeGroup { elem, .. }) | Type::Reference(TypeReference { elem, .. }) => {
+            return extract_type_args(elem)
+        }
         Type::Path(type_path) => type_path.path.segments.last(),
         _ => None,
     }?;

--- a/ts-rs/tests/lifetimes.rs
+++ b/ts-rs/tests/lifetimes.rs
@@ -10,3 +10,25 @@ fn contains_borrow() {
 
     assert_eq!(S::decl(), "interface S { s: string, }")
 }
+
+#[test]
+fn contains_borrow_type_args() {
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct B<'a, T: 'a> {
+        a: &'a T,
+    }
+
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct A<'a> {
+        a: &'a &'a &'a Vec<u32>,                        //Multiple References
+        b: &'a Vec<B<'a, u32>>,                         //Nesting
+        c: &'a std::collections::HashMap<String, bool>, //Multiple type args
+    }
+
+    assert_eq!(
+        A::decl(),
+        "interface A { a: Array<number>, b: Array<B<number>>, c: Record<string, boolean>, }"
+    );
+}


### PR DESCRIPTION
Borrowed types' type arguments weren't previously being included in the typescript export.
e.g.
```rust
struct A<'a> {
    b: &'a Vec<usize>,
}
```
Would be exported as: 
```typescript
interface A { b: Array, }
```


With this pr it's exported correctly as:
```typescript
interface A { b: Array<number>, }
```
