### PR TITLE
Implement TS trait for slices

### DIFF
--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ts-rs"
-version = "7.0.0"
+version = "7.1.0"
 authors = ["Moritz Bischof <moritz.bischof1@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -583,6 +583,7 @@ impl_shadow!(as Vec<T>: impl<T: TS> TS for HashSet<T>);
 impl_shadow!(as Vec<T>: impl<T: TS> TS for BTreeSet<T>);
 impl_shadow!(as HashMap<K, V>: impl<K: TS, V: TS> TS for BTreeMap<K, V>);
 impl_shadow!(as Vec<T>: impl<T: TS, const N: usize> TS for [T; N]);
+impl_shadow!(as Vec<T>: impl<T: TS> TS for [T]);
 
 impl_wrapper!(impl<T: TS + ?Sized> TS for Box<T>);
 impl_wrapper!(impl<T: TS + ?Sized> TS for std::sync::Arc<T>);


### PR DESCRIPTION
Use `impl_shadow!` macro to implement `TS` for slices of type `T: TS`.

This allows for structs like this: 
```rust
#[derive(ts_rs::TS)]
#[export, export_to = "./bindings/"]
struct Foo {
    arr: Box<[u8]>
}
```

This is great for saving memory when dealing with immutable collections of unknown size, since there is no `capacity` to store like there is with `Vec<T>`