### PR TITLE
Make sure that `rename_all = "camelCase"` works like in serde

### DIFF
--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -32,9 +32,29 @@ impl Inflection {
         match self {
             Inflection::Lower => string.to_lowercase(),
             Inflection::Upper => string.to_uppercase(),
-            Inflection::Camel => string.to_camel_case(),
+            Inflection::Camel => {
+                let pascal = Inflection::apply(Inflection::Pascal, string);
+                pascal[..1].to_ascii_lowercase() + &pascal[1..]
+            }
             Inflection::Snake => string.to_snake_case(),
-            Inflection::Pascal => string.to_pascal_case(),
+            Inflection::Pascal => {
+                let mut s = String::with_capacity(string.len());
+
+                let mut capitalize = true;
+                for c in string.chars() {
+                    if c == '_' {
+                        capitalize = true;
+                        continue;
+                    } else if capitalize {
+                        s.push(c.to_ascii_uppercase());
+                        capitalize = false;
+                    } else {
+                        s.push(c.to_ascii_lowercase())
+                    }
+                }
+
+                s
+            }
             Inflection::ScreamingSnake => string.to_screaming_snake_case(),
             Inflection::Kebab => string.to_kebab_case(),
         }

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::box_collection)]
 #![allow(dead_code)]
 
 use std::{

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -14,6 +14,30 @@ fn rename_all() {
     assert_eq!(Rename::inline(), "{ A: number, B: number, }");
 }
 
+#[test]
+fn rename_all_camel_case() {
+    #[derive(TS)]
+    #[ts(rename_all = "camelCase")]
+    struct Rename {
+        crc32c_hash: i32,
+        b: i32,
+    }
+
+    assert_eq!(Rename::inline(), "{ crc32cHash: number, b: number, }");
+}
+
+#[test]
+fn rename_all_pascal_case() {
+    #[derive(TS)]
+    #[ts(rename_all = "PascalCase")]
+    struct Rename {
+        crc32c_hash: i32,
+        b: i32,
+    }
+
+    assert_eq!(Rename::inline(), "{ Crc32cHash: number, B: number, }");
+}
+
 #[cfg(feature = "serde-compat")]
 #[test]
 fn serde_rename_special_char() {

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code, clippy::blacklisted_name)]
+#![allow(dead_code, clippy::disallowed_names)]
 
 use serde::Serialize;
 use ts_rs::TS;


### PR DESCRIPTION
Fixes #165 

This copies over serde's implementation of Pascal and camelCase to make sure both crates work the same way

edit: typos