### PR TITLE
Fix: rename remaining quiet serde feature uses

### DIFF
--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -99,10 +99,10 @@ pub fn parse_serde_attrs<'a, A: TryFrom<&'a Attribute, Error = Error>>(
         .flat_map(|attr| match A::try_from(attr) {
             Ok(attr) => Some(attr),
             Err(_) => {
-                #[cfg(not(feature = "quiet-serde"))]
+                #[cfg(not(feature = "no-serde-warnings"))]
                 use quote::ToTokens;
 
-                #[cfg(not(feature = "quiet-serde"))]
+                #[cfg(not(feature = "no-serde-warnings"))]
                 warning::print_warning(
                     "failed to parse serde attribute",
                     format!("{}", attr.to_token_stream()),


### PR DESCRIPTION
It looks like a couple uses of the old `quiet-serde` feature were missed in #189 when it was renamed. As a result, warnings will still display with the latest version even with the feature on unfortunately. 