### PR TITLE
Improve support for references

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -91,6 +91,9 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
             dependencies.append(tuple_struct.dependencies);
             return tuple_struct.inline;
         }
+        Type::Reference(syn::TypeReference { ref elem, .. }) => {
+            return format_type(elem, dependencies, generics)
+        }
         _ => (),
     };
 

--- a/ts-rs/tests/references.rs
+++ b/ts-rs/tests/references.rs
@@ -1,0 +1,15 @@
+use ts_rs::TS;
+
+#[test]
+fn references() {
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct FullOfRefs<'a> {
+        str_slice: &'a str,
+        ref_slice: &'a [&'a str],
+        num_ref: &'a i32,
+    }
+
+    assert_eq!(FullOfRefs::inline(), "{ str_slice: string, ref_slice: Array<string>, num_ref: number, }")
+}
+

--- a/ts-rs/tests/slices.rs
+++ b/ts-rs/tests/slices.rs
@@ -17,6 +17,17 @@ fn interface() {
 }
 
 #[test]
+fn slice_ref() {
+    #[derive(TS)]
+    struct Interface<'a> {
+        #[allow(dead_code)]
+        a: &'a [&'a str]
+    }
+
+    assert_eq!(Interface::inline(), "{ a: Array<string>, }")
+}
+
+#[test]
 fn newtype() {
     #[derive(TS)]
     struct Newtype(#[allow(dead_code)] [i32]);


### PR DESCRIPTION
This PR is meant to improve on #183 as I noticed that `&'a [i32]` would turn into just `Array` int TS rather than `Array<number>`.