### PR TITLE
Remove support for "skip_serializing", "skip_deserializing" and "skip_serializing_if"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# master
+
+- Remove support for "skip_serializing", "skip_serializing_if" and "skip_deserializing".
+    - Initially supporting these by skipping a field was a mistake. If a user wishes to skip a field, they can still
+      annotate it with `#[ts(skip)]`

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ Supported serde attributes:
 - `content`
 - `untagged`
 - `skip`
-- `skip_serializing`
-- `skip_deserializing`
-- `skip_serializing_if = "Option::is_none"`
 - `flatten`
 - `default`
+
+Note: `skip_serializing` and `skip_deserializing` are ignored. If you with to exclude a field
+from the generated type, but cannot use `#[serde(skip)]`, use `#[ts(skip)]` instead.
 
 When ts-rs encounters an unsupported serde attribute, a warning is emitted, unless the feature `no-serde-warnings` is enabled.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Supported serde attributes:
 - `flatten`
 - `default`
 
-Note: `skip_serializing` and `skip_deserializing` are ignored. If you with to exclude a field
+Note: `skip_serializing` and `skip_deserializing` are ignored. If you wish to exclude a field
 from the generated type, but cannot use `#[serde(skip)]`, use `#[ts(skip)]` instead.
 
 When ts-rs encounters an unsupported serde attribute, a warning is emitted, unless the feature `no-serde-warnings` is enabled.

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -102,6 +102,6 @@ enum InlineComplexEnum {
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 struct ComplexStruct {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub string_tree: Option<Rc<BTreeSet<String>>>,
 }

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -65,9 +65,6 @@ impl_parse! {
     SerdeFieldAttr(input, out) {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "skip" => out.0.skip = true,
-        "skip_serializing" => out.0.skip = true,
-        "skip_deserializing" => out.0.skip = true,
-        "skip_serializing_if" => out.0.optional = parse_assign_str(input)? == *"Option::is_none",
         "flatten" => out.0.flatten = true,
         // parse #[serde(default)] to not emit a warning
         "default" => {

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -60,7 +60,5 @@ impl_parse! {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "skip" => out.0.skip = true,
-        "skip_serializing" => out.0.skip = true,
-        "skip_deserializing" => out.0.skip = true,
     }
 }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -132,7 +132,7 @@
 //! - `flatten`
 //! - `default`
 //!
-//! Note: `skip_serializing` and `skip_deserializing` are ignored. If you with to exclude a field
+//! Note: `skip_serializing` and `skip_deserializing` are ignored. If you wish to exclude a field
 //! from the generated type, but cannot use `#[serde(skip)]`, use `#[ts(skip)]` instead.
 //!
 //! When ts-rs encounters an unsupported serde attribute, a warning is emitted, unless the feature `no-serde-warnings` is enabled.

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -129,11 +129,11 @@
 //! - `content`
 //! - `untagged`
 //! - `skip`
-//! - `skip_serializing`
-//! - `skip_deserializing`
-//! - `skip_serializing_if = "Option::is_none"`
 //! - `flatten`
 //! - `default`
+//!
+//! Note: `skip_serializing` and `skip_deserializing` are ignored. If you with to exclude a field
+//! from the generated type, but cannot use `#[serde(skip)]`, use `#[ts(skip)]` instead.
 //!
 //! When ts-rs encounters an unsupported serde attribute, a warning is emitted, unless the feature `no-serde-warnings` is enabled.
 //!

--- a/ts-rs/tests/optional_field.rs
+++ b/ts-rs/tests/optional_field.rs
@@ -7,14 +7,10 @@ use ts_rs::TS;
 struct Optional {
     #[ts(optional)]
     a: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    b: Option<String>,
+    b: Option<String>
 }
 
 #[test]
 fn test() {
-    #[cfg(not(feature = "serde-compat"))]
     assert_eq!(Optional::inline(), "{ a?: number, b: string | null, }");
-    #[cfg(feature = "serde-compat")]
-    assert_eq!(Optional::inline(), "{ a?: number, b?: string, }")
 }


### PR DESCRIPTION
We plan on removing "support" for these in the next major release.  
Currently, fields annotated with one of these serde annotations are skipped. However, this behavious is incorrect, depending on your usecase. 

Resolves #143
