### PR TITLE
Fix CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ generate typescript interface/type declarations from rust types
 
 <div align="center">
 <!-- Github Actions -->
-<img src="https://img.shields.io/github/workflow/status/Aleph-Alpha/ts-rs/Test?style=flat-square" alt="actions status" />
+<img src="https://img.shields.io/github/actions/workflow/status/Aleph-Alpha/ts-rs/test.yml?branch=main" alt="actions status" />
 <a href="https://crates.io/crates/ts-rs">
 <img src="https://img.shields.io/crates/v/ts-rs.svg?style=flat-square"
 alt="Crates.io version" />

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! <div align="center">
 //! <!-- Github Actions -->
-//! <img src="https://img.shields.io/github/workflow/status/Aleph-Alpha/ts-rs/Test?style=flat-square" alt="actions status" />
+//! <img src="https://img.shields.io/github/actions/workflow/status/Aleph-Alpha/ts-rs/test.yml?branch=main" alt="actions status" />
 //! <a href="https://crates.io/crates/ts-rs">
 //! <img src="https://img.shields.io/crates/v/ts-rs.svg?style=flat-square"
 //! alt="Crates.io version" />


### PR DESCRIPTION
The current CI badge is showing a `shields` issue rather than the CI status