### PR TITLE
Implement `#[ts(optional = nullable)]` 

### DIFF
--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -30,7 +30,7 @@ pub(crate) fn newtype(
         flatten,
     } = FieldAttr::from_attrs(&inner.attrs)?;
 
-    match (&rename_inner, skip, optional, flatten) {
+    match (&rename_inner, skip, optional.optional, flatten) {
         (Some(_), ..) => syn_err!("`rename` is not applicable to newtype fields"),
         (_, true, ..) => return super::unit::null(attr, name),
         (_, _, true, ..) => syn_err!("`optional` is not applicable to newtype fields"),

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -74,7 +74,7 @@ fn format_field(
     if rename.is_some() {
         syn_err!("`rename` is not applicable to tuple structs")
     }
-    if optional {
+    if optional.optional {
         syn_err!("`optional` is not applicable to tuple fields")
     }
     if flatten {

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -227,7 +227,10 @@ mod export;
 ///   Skip this field  
 ///
 /// - `#[ts(optional)]`:  
-///   Indicates the field may be omitted from the serialized struct
+///   May be applied on a struct field of type `Option<T>`.
+///   By default, such a field would turn into `t: T | null`.
+///   If `#[ts(optional)]` is present, `t?: T` is generated instead.
+///   If `#[ts(optional = nullable)]` is present, `t?: T | null` is generated.
 ///
 /// - `#[ts(flatten)]`:  
 ///   Flatten this field (only works if the field is a struct)  

--- a/ts-rs/tests/optional_field.rs
+++ b/ts-rs/tests/optional_field.rs
@@ -3,14 +3,73 @@
 use serde::Serialize;
 use ts_rs::TS;
 
-#[derive(Serialize, TS)]
-struct Optional {
-    #[ts(optional)]
-    a: Option<i32>,
-    b: Option<String>,
+#[test]
+fn in_struct() {
+    #[derive(Serialize, TS)]
+    struct Optional {
+        #[ts(optional)]
+        a: Option<i32>,
+        #[ts(optional = nullable)]
+        b: Option<i32>,
+        c: Option<i32>,
+    }
+
+    let a = "a?: number";
+    let b = "b?: number | null";
+    let c = "c: number | null";
+    assert_eq!(Optional::inline(), format!("{{ {a}, {b}, {c}, }}"));
 }
 
 #[test]
-fn test() {
-    assert_eq!(Optional::inline(), "{ a?: number, b: string | null, }");
+fn in_enum() {
+    #[derive(Serialize, TS)]
+    enum Optional {
+        A { #[ts(optional)] a: Option<i32> },
+        B { b: Option<String>, }
+    }
+
+    assert_eq!(Optional::inline(), r#"{ "A": { a?: number, } } | { "B": { b: string | null, } }"#);
+}
+
+#[test]
+fn flatten() {
+    #[derive(Serialize, TS)]
+    struct Optional {
+        #[ts(optional)]
+        a: Option<i32>,
+        #[ts(optional = nullable)]
+        b: Option<i32>,
+        c: Option<i32>,
+    }
+
+    #[derive(Serialize, TS)]
+    struct Flatten {
+        #[ts(flatten)]
+        x: Optional,
+    }
+
+    assert_eq!(Flatten::inline(), Optional::inline());
+}
+
+#[test]
+fn inline() {
+    #[derive(Serialize, TS)]
+    struct Optional {
+        #[ts(optional)]
+        a: Option<i32>,
+        #[ts(optional = nullable)]
+        b: Option<i32>,
+        c: Option<i32>,
+    }
+
+    #[derive(Serialize, TS)]
+    struct Inline {
+        #[ts(inline)]
+        x: Optional,
+    }
+
+    let a = "a?: number";
+    let b = "b?: number | null";
+    let c = "c: number | null";
+    assert_eq!(Inline::inline(), format!("{{ x: {{ {a}, {b}, {c}, }}, }}"));
 }


### PR DESCRIPTION
This PR implements `#[ts(optional = nullable)]`, as discussed in #112.
`#[ts(optional)] Option<T>` still generates `t?: T`, while `#[ts(optional = nullable)]` generates `t?: T | null`.

I plan on following this up at some point with support for the serde attributes outlined in #112.
