### PR TITLE
Fix bug  in #212

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -64,7 +64,7 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
         }
 
         return quote!(
-            match <#generic_ident>::name().as_str() {
+            match <#generic_ident>::inline().as_str() {
                 // When exporting a generic, the default type used is `()`,
                 // which gives "null" when calling `.name()`. In this case, we
                 // want to preserve the type param's identifier as the name used

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -147,6 +147,7 @@ fn generic_struct() {
 }
 
 #[test]
+// https://github.com/Aleph-Alpha/ts-rs/issues/56 TODO
 fn inline() {
     #[derive(TS)]
     struct Generic<T> {
@@ -159,13 +160,13 @@ fn inline() {
         #[ts(inline)]
         gi: Generic<String>,
         #[ts(flatten)]
-        t: Generic<String>,
+        t: Generic<Vec<String>>,
     }
 
     assert_eq!(Generic::<()>::decl(), "type Generic<T> = { t: T, }");
     assert_eq!(
         Container::decl(),
-        "type Container = { g: Generic<string>, gi: { t: string, }, t: string, }"
+        "type Container = { g: Generic<string>, gi: { t: string, }, t: Array<string>, }"
     );
 }
 


### PR DESCRIPTION
`Vec<string>` was turning into `Array` using `inline` instead of `name` should resolve the issue