### PR TITLE
Inline generics with default types works, as long as there are no trait bounds

### DIFF
--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -59,7 +59,7 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
         let generic_ident = generic.ident.clone();
         let generic_ident_str = generic_ident.to_string();
 
-        if !generic.bounds.is_empty() || generic.default.is_some() {
+        if !generic.bounds.is_empty() {
             return quote!(#generic_ident_str.to_owned());
         }
 

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -147,7 +147,6 @@ fn generic_struct() {
 }
 
 #[test]
-// https://github.com/Aleph-Alpha/ts-rs/issues/56 TODO
 fn inline() {
     #[derive(TS)]
     struct Generic<T> {
@@ -173,6 +172,8 @@ fn inline() {
 #[test]
 #[ignore = "We haven't figured out how to inline generics with bounds yet"]
 fn inline_with_bounds() {
+    todo!("FIX ME: https://github.com/Aleph-Alpha/ts-rs/issues/214");
+
     #[derive(TS)]
     struct Generic<T: ToString> {
         t: T,
@@ -181,13 +182,16 @@ fn inline_with_bounds() {
     #[derive(TS)]
     struct Container {
         g: Generic<String>,
+
         #[ts(inline)]
         gi: Generic<String>,
+
         #[ts(flatten)]
         t: Generic<u32>,
     }
 
     assert_eq!(Generic::<&'static str>::decl(), "type Generic<T> = { t: T, }");
+    //                   ^^^^^^^^^^^^ Replace with something else
     assert_eq!(
         Container::decl(),
         "type Container = { g: Generic<string>, gi: { t: string, }, t: number, }"
@@ -196,7 +200,6 @@ fn inline_with_bounds() {
 }
 
 #[test]
-#[ignore = "We haven't figured out how to inline generics with defaults yet"]
 fn inline_with_default() {
     #[derive(TS)]
     struct Generic<T = String> {
@@ -206,17 +209,18 @@ fn inline_with_default() {
     #[derive(TS)]
     struct Container {
         g: Generic<String>,
+        
         #[ts(inline)]
         gi: Generic<String>,
+
         #[ts(flatten)]
         t: Generic<u32>,
     }
 
-    assert_eq!(Generic::<&'static str>::decl(), "type Generic<T = string> = { t: T, }");
+    assert_eq!(Generic::<()>::decl(), "type Generic<T = string> = { t: T, }");
     assert_eq!(
         Container::decl(),
         "type Container = { g: Generic<string>, gi: { t: string, }, t: number, }"
-        // Actual output: { g: Generic<string>, gi: { t: T, }, t: T, }
     );
 }
 


### PR DESCRIPTION
I found that `#[export]` doesn't magically figure out a type for trait bounds as I thought was happening (I saw the tests with trait bounds use `decl::<&'static str>` and had no idea how that was happening) and instead **always** uses `()`

This means that checking for `"null"` works with default types, and would work with bounds if we could implement foreign traits on `()`, which sadly we can't due to the orphan rule.

I opened a separate issue for this #214