### PR TITLE
Add support for IndexVec

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ When running `cargo test`, the TypeScript bindings will be exported to the file 
 - `indexmap-impl`
 
   Implement `TS` for `IndexMap` and `IndexSet` from indexmap
+- `index_vec-impl`
 
+  Implement `TS` for `IndexVec` from index_vec
 - `ordered-float-impl`
 
   Implement `TS` for `OrderedFloat` from ordered_float

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -32,6 +32,7 @@ heapless-impl = ["heapless"]
 semver-impl = ["semver"]
 no-serde-warnings = ["ts-rs-macros/no-serde-warnings"]
 import-esm = []
+index_vec-impl = ["index_vec"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -53,3 +54,4 @@ semver = { version = "1.0.21", optional = true }
 thiserror = "1"
 indexmap = { version = "2.0.0", optional = true }
 ordered-float = { version = "3.0.0", optional = true }
+index_vec = { version = "0.1.0", optional = true }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -98,9 +98,11 @@
 //!   Implement `TS` for types from bytes    
 //! - `indexmap-impl`  
 //!
-//!   Implement `TS` for `IndexMap` and `IndexSet` from indexmap  
+//!   Implement `TS` for `IndexMap` and `IndexSet` from indexmap
+//! - `index_vec-impl`
 //!
-//! - `ordered-float-impl`  
+//!   Implement `TS` for `IndexVec` from index_vec
+//! - `ordered-float-impl`
 //!
 //!   Implement `TS` for `OrderedFloat` from ordered_float
 //!
@@ -737,6 +739,9 @@ impl_shadow!(as HashMap<K, V>: impl<K: TS, V: TS> TS for indexmap::IndexMap<K, V
 
 #[cfg(feature = "heapless-impl")]
 impl_shadow!(as Vec<T>: impl<T: TS, const N: usize> TS for heapless::Vec<T, N>);
+
+#[cfg(feature = "index_vec-impl")]
+impl_shadow!(as Vec<T>: impl<K: index_vec::Idx, T: TS> TS for index_vec::IndexVec<K, T>);
 
 #[cfg(feature = "semver-impl")]
 impl_primitives! { semver::Version => "string" }

--- a/ts-rs/tests/index_vec.rs
+++ b/ts-rs/tests/index_vec.rs
@@ -1,0 +1,19 @@
+#![cfg(feature = "index_vec-impl")]
+
+use index_vec::{define_index_type, IndexVec};
+use ts_rs::TS;
+
+#[test]
+fn index_vec() {
+    define_index_type! {
+        pub struct MyIdx = u32;
+    }
+
+    #[derive(TS)]
+    #[allow(dead_code)]
+    struct Indexes {
+        vec: IndexVec<MyIdx, String>,
+    }
+
+    assert_eq!(Indexes::decl(), "type Indexes = { vec: Array<string>, }")
+}


### PR DESCRIPTION
Hi, I'd like to add support for `index_vec::IndedVec`. I've decided to make this a shadow impl for `Vec` and users of the feature will have to decide how to serialize indices into numbers. 