### PR TITLE
Fix flatten generic by changing `TS::name`

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -97,6 +97,7 @@ impl DerivedTS {
             .unwrap_or_else(TokenStream::new);
 
         let impl_start = generate_impl(&rust_ty, &generics);
+        let generic_idents = generics.type_params().map(|x| x.ident.clone());
         quote! {
             #impl_start {
                 const EXPORT_TO: Option<&'static str> = Some(#export_to);
@@ -108,7 +109,11 @@ impl DerivedTS {
                     #decl
                 }
                 fn name() -> String {
-                    #name.to_owned()
+                    let generics: Vec<String> = vec![#(<#generic_idents>::name()),*];
+                    match generics.is_empty() {
+                        true => #name.to_owned(),
+                        false => format!("{}<{}>", #name, generics.join(", ")),
+                    }
                 }
                 fn inline() -> String {
                     #inline

--- a/macros/src/types/generics.rs
+++ b/macros/src/types/generics.rs
@@ -64,15 +64,12 @@ pub fn format_type(ty: &Type, dependencies: &mut Dependencies, generics: &Generi
         }
 
         return quote!(
-            match <#generic_ident>::inline().as_str() {
-                // When exporting a generic, the default type used is `()`,
-                // which gives "null" when calling `.name()`. In this case, we
-                // want to preserve the type param's identifier as the name used
+            match <#generic_ident>::name().as_str() {
                 "null" => #generic_ident_str.to_owned(),
 
-                // If name is not "null", a type has been provided, so we use its
-                // name instead
-                x => x.to_owned()
+                x => {
+                    x.to_owned()
+                }
             }
         );
     }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -298,7 +298,10 @@ pub trait TS {
 
     /// Name of this type in TypeScript, with type arguments.
     fn name_with_type_args(args: Vec<String>) -> String {
-        format!("{}<{}>", Self::name().split_once('<').unwrap().0, args.join(", "))
+        match Self::name().split_once('<') {
+            None => Self::name(),
+            Some(x) => format!("{}<{}>", x.0, args.join(", "))
+        }
     }
 
     /// Formats this types definition in TypeScript, e.g `{ user_id: number }`.

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -256,7 +256,7 @@ fn default() {
         // #[ts(inline)]
         // xi2: X<i32>
     }
-    assert_eq!(Y::decl(), "type Y = { a1: A, a2: A<number>, }")
+    assert_eq!(Y::decl(), "type Y = { a1: A<string>, a2: A<number>, }")
 }
 
 #[test]
@@ -353,7 +353,10 @@ fn deeply_nested() {
 #[test]
 fn inline_generic_enum() {
     #[derive(TS)]
-    struct SomeType(String);
+    struct OtherType<T>(T);
+
+    #[derive(TS)]
+    struct SomeType<T>(OtherType<T>);
 
     #[derive(TS)]
     enum MyEnum<A, B> {
@@ -365,7 +368,7 @@ fn inline_generic_enum() {
     struct Parent {
         e: MyEnum<i32, i32>,
         #[ts(inline)]
-        e1: MyEnum<i32, SomeType>
+        e1: MyEnum<i32, SomeType<String>>
     }
 
     // This fails!
@@ -375,7 +378,7 @@ fn inline_generic_enum() {
         Parent::decl(),
         "type Parent = { \
             e: MyEnum<number, number>, \
-            e1: { \"VariantA\": number } | { \"VariantB\": SomeType }, \
+            e1: { \"VariantA\": number } | { \"VariantB\": SomeType<string> }, \
         }"
     );
 }

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -349,3 +349,33 @@ fn deeply_nested() {
          }"
     );
 }
+
+#[test]
+fn inline_generic_enum() {
+    #[derive(TS)]
+    struct SomeType(String);
+
+    #[derive(TS)]
+    enum MyEnum<A, B> {
+        VariantA(A),
+        VariantB(B)
+    }
+
+    #[derive(TS)]
+    struct Parent {
+        e: MyEnum<i32, i32>,
+        #[ts(inline)]
+        e1: MyEnum<i32, SomeType>
+    }
+
+    // This fails!
+    // The #[ts(inline)] seems to inline recursively, so not only the definition of `MyEnum`, but
+    // also the definition of `SomeType`.
+    assert_eq!(
+        Parent::decl(),
+        "type Parent = { \
+            e: MyEnum<number, number>, \
+            e1: { \"VariantA\": number } | { \"VariantB\": SomeType }, \
+        }"
+    );
+}

--- a/ts-rs/tests/type_alias.rs
+++ b/ts-rs/tests/type_alias.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use ts_rs::TS;
+
+type TypeAlias = HashMap<String, String>;
+
+#[derive(TS)]
+enum Enum {
+    A(TypeAlias),
+    B(HashMap<String, String>),
+}
+
+#[derive(TS)]
+struct Struct {
+    a: TypeAlias,
+    b: HashMap<String, String>
+}
+
+#[test]
+fn type_alias() {
+    assert_eq!(
+        Enum::decl(),
+        r#"type Enum = { "A": Record<string, string> } | { "B": Record<string, string> };"#
+    );
+
+    assert_eq!(
+        Struct::decl(),
+        "type Struct = { a: Record<string, string>, b: Record<string, string>, }"
+    );
+}
+


### PR DESCRIPTION
An attempt at fixing the problems caused by #215 by changing the name method to return the name of the generics

The reason I chose to do this is that there is no reasonable way to call `name_with_type_args` from the place where the problem showed up, so either `inline` or `name` would have to be used instead.

`inline` was being used, and causing problems
`name`, as showed by my attempt to fix it in #215, wouldn't brring T's generics

Out of sheer luck, this fixes #70

@NyxCode despite being a small change regarding how much code changed, this is a reasonably big change in how the library works, so I'd really like your feedback on this one