### PR TITLE
Use `workspace.resolver = "2"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["config", "macros", "ts-rs", "example"]
+resolver = "2"


### PR DESCRIPTION
We have a compiler warning about the version of the resolver being in conflict with the rust edition of the library

![image](https://github.com/Aleph-Alpha/ts-rs/assets/131818645/cea94827-177e-423b-967b-09f2c1f52fbf)

Adding this line to Cargo.toml should resolve it. There shouldn't be any side effects since all crates in the workspace use `edition = "2021"`, which implies `resolver = "2"`