### PR TITLE
Remove `TS::trasparent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added `TS::generics()` ([#241](https://github.com/Aleph-Alpha/ts-rs/pull/241))
 - Added `TS::WithoutGenerics` ([#241](https://github.com/Aleph-Alpha/ts-rs/pull/241))
 - `Result`, `Option`, `HashMap` and `Vec` had their implementations of `TS` changed ([#241](https://github.com/Aleph-Alpha/ts-rs/pull/241))
+- Removed `TS::transparent()` ([#243](https://github.com/Aleph-Alpha/ts-rs/pull/243))
 
 ### Features
 

--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -13,7 +13,6 @@ impl Dependencies {
     }
 
     /// Adds the given type.
-    /// If the type is transparent, then we'll get resolve the child dependencies during runtime.
     pub fn push(&mut self, ty: &Type) {
         self.0.push(quote![.push::<#ty>()]);
         self.0.push(quote![

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -87,10 +87,6 @@ impl DerivedTS {
                 {
                     #dependencies
                 }
-
-                fn transparent() -> bool {
-                    false
-                }
             }
 
             #export
@@ -145,7 +141,6 @@ impl DerivedTS {
                 impl TS for #generics {
                     type WithoutGenerics = #generics;
                     fn name() -> String { stringify!(#generics).to_owned() }
-                    fn transparent() -> bool { false }
                 }
             )*
         }

--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -14,7 +14,6 @@ macro_rules! impl_dummy {
             type WithoutGenerics = $t;
             fn name() -> String { String::new() }
             fn inline() -> String { String::new() }
-            fn transparent() -> bool { false }
         }
     )*};
 }
@@ -33,9 +32,6 @@ impl<T: TimeZone + 'static> TS for DateTime<T> {
     fn inline() -> String {
         "string".to_owned()
     }
-    fn transparent() -> bool {
-        false
-    }
 }
 
 impl<T: TimeZone + 'static> TS for Date<T> {
@@ -48,8 +44,5 @@ impl<T: TimeZone + 'static> TS for Date<T> {
     }
     fn inline() -> String {
         "string".to_owned()
-    }
-    fn transparent() -> bool {
-        false
     }
 }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -502,6 +502,7 @@ macro_rules! impl_shadow {
     (as $s:ty: $($impl:tt)*) => {
         $($impl)* {
             type WithoutGenerics = <$s as TS>::WithoutGenerics;
+            fn ident() -> String { <$s>::ident() }
             fn name() -> String { <$s>::name() }
             fn inline() -> String { <$s>::inline() }
             fn inline_flattened() -> String { <$s>::inline_flattened() }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -683,33 +683,11 @@ impl<I: TS> TS for Range<I> {
     where
         Self: 'static,
     {
-        use std::marker::PhantomData;
-        ((PhantomData::<I>,), I::generics())
+        I::generics().push::<I>()
     }
 }
 
-impl<I: TS> TS for RangeInclusive<I> {
-    type WithoutGenerics = RangeInclusive<Dummy>;
-    fn name() -> String {
-        format!("{{ start: {}, end: {}, }}", I::name(), I::name())
-    }
-
-    fn dependency_types() -> impl TypeList
-    where
-        Self: 'static,
-    {
-        I::dependency_types()
-    }
-
-    fn generics() -> impl TypeList
-    where
-        Self: 'static,
-    {
-        use std::marker::PhantomData;
-        ((PhantomData::<I>,), I::generics())
-    }
-}
-
+impl_shadow!(as Range<I>: impl<I: TS> TS for RangeInclusive<I>);
 impl_shadow!(as Vec<T>: impl<T: TS, H> TS for HashSet<T, H>);
 impl_shadow!(as Vec<T>: impl<T: TS> TS for BTreeSet<T>);
 impl_shadow!(as HashMap<K, V>: impl<K: TS, V: TS> TS for BTreeMap<K, V>);


### PR DESCRIPTION
This PR is meant to remove the `TS::transparent` method, as it was rendered useless by #241, always return `false` with the exception of `Range` and `RangeInclusive`