### PR TITLE
Parse `#[ts(tag = "...")]` on structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Support `#[serde(untagged)]` on individual enum variants ([#226](https://github.com/Aleph-Alpha/ts-rs/pull/226))
 - Support for `#[serde(rename_all_fields = "...")]` ([#225](https://github.com/Aleph-Alpha/ts-rs/pull/225))
 - Export Rust doc comments/attributes on structs/enums as TSDoc strings ([#187](https://github.com/Aleph-Alpha/ts-rs/pull/187))
+- Implement `#[ts(...)]` equivalent for `#[serde(tag = "...")]` being used on a struct with named fields ([#244](https://github.com/Aleph-Alpha/ts-rs/pull/244))
 
 ### Fixes
 

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -73,6 +73,7 @@ impl_parse! {
     StructAttr(input, out) {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
+        "tag" => out.tag = Some(parse_assign_str(input)?),
         "export" => out.export = true,
         "export_to" => out.export_to = Some(parse_assign_str(input)?)
     }

--- a/ts-rs/tests/struct_tag.rs
+++ b/ts-rs/tests/struct_tag.rs
@@ -1,17 +1,19 @@
 #![allow(dead_code)]
 
+#[cfg(feature = "serde-compat")]
 use serde::Serialize;
 use ts_rs::TS;
 
-#[derive(TS, Serialize)]
-#[serde(tag = "type")]
+#[derive(TS)]
+#[cfg_attr(feature = "serde-compat", derive(Serialize))]
+#[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
 struct TaggedType {
     a: i32,
     b: i32,
 }
 
 #[test]
-#[cfg(feature = "serde-compat")]
 fn test() {
     assert_eq!(
         TaggedType::inline(),
@@ -19,8 +21,3 @@ fn test() {
     )
 }
 
-#[test]
-#[cfg(not(feature = "serde-compat"))]
-fn test() {
-    assert_eq!(TaggedType::inline(), "{ a: number, b: number, }")
-}


### PR DESCRIPTION
This PR adds a `#[ts(...)]` equivalent to `#[serde(tag = "...")]` on structs