### PR TITLE
bug: `#[ts(export_to = "../path")]` can cause `diff_paths` to fail

### DIFF
--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
+path-clean = "1"
 heapless = { version = "0.7", optional = true }
 ts-rs-macros = { version = "7.1.1", path = "../macros" }
 dprint-plugin-typescript = { version = "0.85.1", optional = true }

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -38,7 +38,6 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
-path-clean = "1"
 heapless = { version = "0.7", optional = true }
 ts-rs-macros = { version = "7.1.1", path = "../macros" }
 dprint-plugin-typescript = { version = "0.85.1", optional = true }

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
+use path_clean::PathClean;
 use thiserror::Error;
 use ExportError::*;
 
@@ -221,6 +222,14 @@ fn import_path(from: &Path, import: &Path) -> String {
     }
 }
 
+fn to_absolute_path(path: &Path) -> PathBuf {
+    let Ok(current_path) = std::env::current_dir() else {
+        return path.to_owned()
+    };
+
+    current_path.join(path).clean()
+}
+
 // Construct a relative path from a provided base directory path to the provided path.
 //
 // Copyright 2012-2015 The Rust Project Developers.
@@ -238,12 +247,12 @@ where
     P: AsRef<Path>,
     B: AsRef<Path>,
 {
-    let path = path.as_ref();
-    let base = base.as_ref();
+    let path = to_absolute_path(path.as_ref());
+    let base = to_absolute_path(base.as_ref());
 
     if path.is_absolute() != base.is_absolute() {
         if path.is_absolute() {
-            Some(PathBuf::from(path))
+            Some(path)
         } else {
             None
         }

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -8,7 +8,6 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
-use path::PathAbsolute;
 use thiserror::Error;
 
 use crate::TS;
@@ -160,12 +159,11 @@ pub(crate) fn export_type_to_string<T: TS + ?Sized + 'static>() -> Result<String
 
 /// Compute the output path to where `T` should be exported.
 fn output_path<T: TS + ?Sized>() -> Result<PathBuf, ExportError> {
-    Path::new(
+    path::absolute(Path::new(
         &T::get_export_to()
             .ok_or_else(|| std::any::type_name::<T>())
             .map_err(ExportError::CannotBeExported)?,
-    )
-    .absolute()
+    ))
 }
 
 /// Push the declaration of `T`
@@ -244,8 +242,8 @@ where
 {
     use Component as C;
 
-    let path = path.absolute()?;
-    let base = base.absolute()?;
+    let path = path::absolute(path)?;
+    let base = path::absolute(base)?;
 
     let mut ita = path.components();
     let mut itb = base.components();

--- a/ts-rs/src/export/path.rs
+++ b/ts-rs/src/export/path.rs
@@ -3,33 +3,29 @@ use std::path::{Component as C, Path, PathBuf};
 use super::ExportError as E;
 
 const ERROR_MESSAGE: &str = r#"The path provided with `#[ts(export_to = "..")]` is not valid"#;
-pub trait PathAbsolute: AsRef<Path> {
-    fn absolute(&self) -> Result<PathBuf, E> {
-        let original_path = self.as_ref();
+pub fn absolute<T: AsRef<Path>>(path: T) -> Result<PathBuf, E> {
+    let path = path.as_ref();
 
-        if original_path.is_absolute() {
-            return Ok(original_path.to_owned());
-        }
-
-        let path = std::env::current_dir()?.join(original_path);
-
-        let mut out = Vec::new();
-        for comp in path.components() {
-            match comp {
-                C::CurDir => (),
-                C::ParentDir => {
-                    out.pop().ok_or(E::CannotBeExported(ERROR_MESSAGE))?;
-                }
-                comp => out.push(comp),
-            }
-        }
-
-        Ok(if !out.is_empty() {
-            out.iter().collect()
-        } else {
-            PathBuf::from(".")
-        })
+    if path.is_absolute() {
+        return Ok(path.to_owned());
     }
-}
 
-impl<T: AsRef<Path>> PathAbsolute for T {}
+    let path = std::env::current_dir()?.join(path);
+
+    let mut out = Vec::new();
+    for comp in path.components() {
+        match comp {
+            C::CurDir => (),
+            C::ParentDir => {
+                out.pop().ok_or(E::CannotBeExported(ERROR_MESSAGE))?;
+            }
+            comp => out.push(comp),
+        }
+    }
+
+    Ok(if !out.is_empty() {
+        out.iter().collect()
+    } else {
+        PathBuf::from(".")
+    })
+}

--- a/ts-rs/src/export/path.rs
+++ b/ts-rs/src/export/path.rs
@@ -1,0 +1,35 @@
+use std::path::{Component as C, Path, PathBuf};
+
+use super::ExportError as E;
+
+const ERROR_MESSAGE: &str = r#"The path provided with `#[ts(export_to = "..")]` is not valid"#;
+pub trait PathAbsolute: AsRef<Path> {
+    fn absolute(&self) -> Result<PathBuf, E> {
+        let original_path = self.as_ref();
+
+        if original_path.is_absolute() {
+            return Ok(original_path.to_owned());
+        }
+
+        let path = std::env::current_dir()?.join(original_path);
+
+        let mut out = Vec::new();
+        for comp in path.components() {
+            match comp {
+                C::CurDir => (),
+                C::ParentDir => {
+                    out.pop().ok_or(E::CannotBeExported(ERROR_MESSAGE))?;
+                }
+                comp => out.push(comp),
+            }
+        }
+
+        Ok(if !out.is_empty() {
+            out.iter().collect()
+        } else {
+            PathBuf::from(".")
+        })
+    }
+}
+
+impl<T: AsRef<Path>> PathAbsolute for T {}

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -562,10 +562,7 @@ impl<T: TS, E: TS> TS for Result<T, E> {
     where
         Self: 'static,
     {
-        T::generics()
-            .push::<T>()
-            .extend(E::generics())
-            .push::<E>()
+        T::generics().push::<T>().extend(E::generics()).push::<E>()
     }
 }
 
@@ -658,10 +655,7 @@ impl<K: TS, V: TS, H> TS for HashMap<K, V, H> {
     where
         Self: 'static,
     {
-        K::generics()
-            .push::<K>()
-            .extend(V::generics())
-            .push::<V>()
+        K::generics().push::<K>().extend(V::generics()).push::<V>()
     }
 }
 

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -4,11 +4,11 @@ use ts_rs::TS;
 #[derive(TS)]
 #[ts(export, export_to = "../ts-rs/tests-out/path_bug/")]
 struct Foo {
-    bar: Bar
+    bar: Bar,
 }
 
 #[derive(TS)]
 #[ts(export_to = "tests-out/path_bug/aaa/")]
 struct Bar {
-    i: i32
+    i: i32,
 }

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -2,7 +2,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/path_bug/../path_bug")]
+#[ts(export, export_to = "../ts-rs/tests-out/path_bug/")]
 struct Foo {
     bar: Bar
 }

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code)]
+use ts_rs::TS;
+
+#[derive(TS)]
+#[ts(export, export_to = "tests-out/path_bug/../path_bug")]
+struct Foo {
+    bar: Bar
+}
+
+#[derive(TS)]
+#[ts(export_to = "tests-out/path_bug/aaa/")]
+struct Bar {
+    i: i32
+}

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -12,3 +12,13 @@ struct Foo {
 struct Bar {
     i: i32,
 }
+
+#[test]
+fn path_bug() {
+    Foo::export().unwrap();
+    Bar::export().unwrap();
+
+    let base = std::env::current_dir().unwrap();
+    assert!(base.join("./tests-out/path_bug/Foo.ts").is_file());
+    assert!(base.join("./tests-out/path_bug/aaa/Bar.ts").is_file());
+}

--- a/ts-rs/tests/struct_tag.rs
+++ b/ts-rs/tests/struct_tag.rs
@@ -20,4 +20,3 @@ fn test() {
         "{ type: \"TaggedType\", a: number, b: number, }"
     )
 }
-


### PR DESCRIPTION
This PR reproduces the potential for paths containing `..` to break `diff_paths`