### PR TITLE
Make `#[ts(export_to = "...")]` relative to `TS_RS_EXPORT_DIR`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
         working-directory: e2e/dependencies/consumer
         run: |
           TS_RS_EXPORT_DIR=custom-bindings cargo t 
-          tsc custom-bindings/* --noEmit --noUnusedLocals --strict
+          shopt -s globstar
+          tsc custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
   e2e-workspace:
     name: Run 'workspace' end-to-end test
     runs-on: ubuntu-latest
@@ -36,7 +37,8 @@ jobs:
         working-directory: e2e/workspace
         run: |
           TS_RS_EXPORT_DIR=custom-bindings cargo t 
-          tsc parent/custom-bindings/* --noEmit --noUnusedLocals --strict
+          shopt -s globstar
+          tsc parent/custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
   e2e-example:
     name: End-to-end test example
     runs-on: ubuntu-latest
@@ -54,7 +56,8 @@ jobs:
         working-directory: example
         run: |
           TS_RS_EXPORT_DIR=custom-bindings cargo t 
-          tsc custom-bindings/* --noEmit --noUnusedLocals --strict
+          shopt -s globstar
+          tsc custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
 
   readme-up-to-date:
     name: Check that README.md is up-to-date
@@ -88,3 +91,8 @@ jobs:
           cargo test --all-features
           shopt -s globstar
           tsc ts-rs/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
+      - name: test with export env
+        run: |
+          TS_RS_EXPORT_DIR=output cargo test --no-default-features
+          shopt -s globstar
+          tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,12 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Test with export env
+        run: |
+          ls
+          TS_RS_EXPORT_DIR=output cargo test --no-default-features
+          shopt -s globstar
+          tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
       - name: No features
         run: |
           cargo test --no-default-features
@@ -91,8 +97,3 @@ jobs:
           cargo test --all-features
           shopt -s globstar
           tsc ts-rs/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
-      - name: test with export env
-        run: |
-          TS_RS_EXPORT_DIR=output cargo test --no-default-features
-          shopt -s globstar
-          tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,6 @@ jobs:
           toolchain: stable
       - name: Test with export env
         run: |
-          ls
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
           shopt -s globstar
           tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -34,43 +34,11 @@ impl DerivedTS {
             .export
             .then(|| self.generate_export_test(&rust_ty, &generics));
 
-        let export_dir = std::option_env!("TS_RS_EXPORT_DIR");
         let export_to = {
             let path = match self.export_to.as_deref() {
-                Some(dirname) if dirname.ends_with('/') => {
-                    export_dir
-                        .map_or_else(
-                            || format!("{}{}.ts", dirname, self.ts_name),
-                            |ts_rs_dir| format!(
-                                "{}/{}{}.ts",
-                                ts_rs_dir.trim_end_matches('/'),
-                                dirname,
-                                self.ts_name,
-                            )
-                        )
-                },
-                Some(filename) => {
-                    export_dir
-                        .map_or_else(
-                            || filename.to_owned(),
-                            |ts_rs_dir| format!(
-                                "{}/{}",
-                                ts_rs_dir.trim_end_matches('/'),
-                                filename,
-                            ),
-                        )
-                },
-                None => {
-                    export_dir
-                        .map_or_else(
-                            || format!("bindings/{}.ts", self.ts_name),
-                            |ts_rs_dir| format!(
-                                "{}/{}.ts",
-                                ts_rs_dir.trim_end_matches('/'),
-                                self.ts_name,
-                            ),
-                        )
-                },
+                Some(dirname) if dirname.ends_with('/') => format!("{}{}.ts", dirname, self.ts_name),
+                Some(filename) => filename.to_owned(),
+                None => format!("bindings/{}.ts", self.ts_name),
             };
 
             quote! {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -34,7 +34,7 @@ impl DerivedTS {
             .export
             .then(|| self.generate_export_test(&rust_ty, &generics));
 
-        let export_dir = std::env::var("TS_RS_EXPORT_DIR").ok();
+        let export_dir = std::option_env!("TS_RS_EXPORT_DIR");
         let export_to = {
             let path = match self.export_to.as_deref() {
                 Some(dirname) if dirname.ends_with('/') => {

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -5,7 +5,7 @@ use std::{
     collections::BTreeMap,
     fmt::Write,
     path::{Component, Path, PathBuf},
-    sync::{Mutex, OnceLock},
+    sync::Mutex,
 };
 
 use thiserror::Error;
@@ -124,30 +124,6 @@ pub(crate) fn export_type_to<T: TS + ?Sized + 'static, P: AsRef<Path>>(
     Ok(())
 }
 
-#[doc(hidden)]
-pub mod __private {
-    use super::*;
-
-    const EXPORT_DIR_ENV_VAR: &str = "TS_RS_EXPORT_DIR";
-    fn provided_default_dir() -> Option<&'static str> {
-        static EXPORT_TO: OnceLock<Option<String>> = OnceLock::new();
-        EXPORT_TO
-            .get_or_init(|| std::env::var(EXPORT_DIR_ENV_VAR).ok())
-            .as_deref()
-    }
-
-    /// Returns the path to where `T` should be exported using the `TS_RS_EXPORT_DIR` environment variable.
-    ///
-    /// This should only be used by the TS derive macro; the `get_export_to` trait method should not
-    /// be overridden if the `#[ts(export_to = ..)]` attribute exists.
-    pub fn get_export_to_path<T: TS + ?Sized>() -> Option<String> {
-        provided_default_dir().map_or_else(
-            || T::EXPORT_TO.map(ToString::to_string),
-            |path| Some(format!("{path}/{}.ts", T::ident())),
-        )
-    }
-}
-
 /// Returns the generated defintion for `T`.
 pub(crate) fn export_type_to_string<T: TS + ?Sized + 'static>() -> Result<String, ExportError> {
     let mut buffer = String::with_capacity(1024);
@@ -160,7 +136,7 @@ pub(crate) fn export_type_to_string<T: TS + ?Sized + 'static>() -> Result<String
 /// Compute the output path to where `T` should be exported.
 fn output_path<T: TS + ?Sized>() -> Result<PathBuf, ExportError> {
     path::absolute(Path::new(
-        &T::get_export_to()
+        T::EXPORT_TO
             .ok_or_else(|| std::any::type_name::<T>())
             .map_err(ExportError::CannotBeExported)?,
     ))
@@ -182,7 +158,7 @@ fn generate_decl<T: TS + ?Sized>(out: &mut String) {
 /// Push an import statement for all dependencies of `T`
 fn generate_imports<T: TS + ?Sized + 'static>(out: &mut String) -> Result<(), ExportError> {
     let export_to =
-        T::get_export_to().ok_or(ExportError::CannotBeExported(std::any::type_name::<T>()))?;
+        T::EXPORT_TO.ok_or(ExportError::CannotBeExported(std::any::type_name::<T>()))?;
     let path = Path::new(&export_to);
 
     let deps = T::dependencies();

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -87,7 +87,7 @@ mod recursive_export {
 /// Export `T` to the file specified by the `#[ts(export_to = ..)]` attribute
 pub(crate) fn export_type<T: TS + ?Sized + 'static>() -> Result<(), ExportError> {
     let path = output_path::<T>()?;
-    export_type_to::<T, _>(&path)
+    export_type_to::<T, _>(path::absolute(path)?)
 }
 
 /// Export `T` to the file specified by the `path` argument.
@@ -134,7 +134,7 @@ pub(crate) fn export_type_to_string<T: TS + ?Sized + 'static>() -> Result<String
 }
 
 /// Compute the output path to where `T` should be exported.
-fn output_path<T: TS + ?Sized>() -> Result<PathBuf, ExportError> {
+pub fn output_path<T: TS + ?Sized>() -> Result<PathBuf, ExportError> {
     let path = std::env::var("TS_RS_EXPORT_DIR")
         .ok()
         .as_deref()
@@ -142,12 +142,10 @@ fn output_path<T: TS + ?Sized>() -> Result<PathBuf, ExportError> {
         .unwrap_or_else(|| Path::new("."))
         .to_owned();
 
-    path::absolute(Path::new(
-        &path.join(
-            T::EXPORT_TO
-                .ok_or_else(|| std::any::type_name::<T>())
-                .map_err(ExportError::CannotBeExported)?,
-        )
+    Ok(path.join(
+        T::EXPORT_TO
+            .ok_or_else(|| std::any::type_name::<T>())
+            .map_err(ExportError::CannotBeExported)?,
     ))
 }
 

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -421,7 +421,17 @@ impl Dependency {
     /// If `T` is not exportable (meaning `T::EXPORT_TO` is `None`), this function will return
     /// `None`
     pub fn from_ty<T: TS + 'static + ?Sized>() -> Option<Self> {
-        let exported_to = T::EXPORT_TO.map(ToOwned::to_owned)?;
+        let base = std::env::var("TS_RS_EXPORT_DIR")
+            .ok()
+            .as_deref()
+            .map(Path::new)
+            .unwrap_or_else(|| Path::new("."))
+            .to_owned();
+
+        let exported_to = base
+            .join(T::EXPORT_TO.map(ToOwned::to_owned)?)
+            .to_string_lossy()
+            .to_string();
         Some(Dependency {
             type_id: TypeId::of::<T>(),
             ts_name: T::ident(),

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -165,9 +165,6 @@ use std::{
 pub use ts_rs_macros::TS;
 
 pub use crate::export::ExportError;
-// Used in generated code. Not public API
-#[doc(hidden)]
-pub use crate::export::__private;
 use crate::typelist::TypeList;
 
 #[cfg(feature = "chrono-impl")]
@@ -304,10 +301,6 @@ pub trait TS {
         }
     }
 
-    fn get_export_to() -> Option<String> {
-        Self::EXPORT_TO.map(ToString::to_string)
-    }
-
     /// Declaration of this type, e.g. `interface User { user_id: number, ... }`.
     /// This function will panic if the type has no declaration.
     ///
@@ -428,7 +421,7 @@ impl Dependency {
     /// If `T` is not exportable (meaning `T::EXPORT_TO` is `None`), this function will return
     /// `None`
     pub fn from_ty<T: TS + 'static + ?Sized>() -> Option<Self> {
-        let exported_to = T::get_export_to()?;
+        let exported_to = T::EXPORT_TO.map(ToOwned::to_owned)?;
         Some(Dependency {
             type_id: TypeId::of::<T>(),
             ts_name: T::ident(),

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{concat, fs};
+use std::{concat, fs, path::PathBuf};
 
 use ts_rs::TS;
 
@@ -96,12 +96,10 @@ struct G {
 
 /* ============================================================================================== */
 
-fn generate_path(path: &str) -> String {
-    let base = std::env::var("TS_RS_EXPORT_DIR").ok()
-        .map(|x| x.trim_end_matches('/').to_owned())
-        .map(|x| format!("{x}/"))
-        .unwrap_or_default();
-    format!("{base}{path}")
+fn generate_path(path: &str) -> PathBuf {
+    std::env::current_dir().unwrap()
+        .join(std::env::var("TS_RS_EXPORT_DIR").unwrap_or_default())
+        .join(path)
 }
 
 #[test]

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -2,7 +2,7 @@
 
 use std::{concat, fs};
 
-use ts_rs::TS;
+use ts_rs::{TS, output_path};
 
 
 /* ============================================================================================== */
@@ -137,7 +137,7 @@ fn export_a() {
         )
     };
 
-    let actual_content = fs::read_to_string(A::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<A>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -183,7 +183,7 @@ fn export_b() {
         )
     };
 
-    let actual_content = fs::read_to_string(B::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<B>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -216,7 +216,7 @@ fn export_c() {
         )
     };
 
-    let actual_content = fs::read_to_string(C::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<C>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -248,7 +248,7 @@ fn export_d() {
             "export type D = null;"
         )
     };
-    let actual_content = fs::read_to_string(D::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<D>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -281,7 +281,7 @@ fn export_e() {
         )
     };
 
-    let actual_content = fs::read_to_string(E::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<E>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -329,7 +329,7 @@ fn export_f() {
         )
     };
 
-    let actual_content = fs::read_to_string(F::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<F>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -377,7 +377,7 @@ fn export_g() {
         )
     };
 
-    let actual_content = fs::read_to_string(G::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<G>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -4,6 +4,8 @@ use std::{concat, fs};
 
 use ts_rs::TS;
 
+const PATH: Option<&str> = std::option_env!("TS_RS_EXPORT_DIR");
+
 /* ============================================================================================== */
 
 /// Doc comment.
@@ -95,6 +97,16 @@ struct G {
 
 /* ============================================================================================== */
 
+fn generate_path(path: &str) -> String {
+    format!(
+        "{}{path}",
+        PATH
+            .map(|x| x.trim_end_matches('/'))
+            .map(|x| format!("{x}/"))
+            .unwrap_or_default()
+    )
+}
+
 #[test]
 fn export_a() {
     A::export().unwrap();
@@ -136,7 +148,9 @@ fn export_a() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/A.ts").unwrap();
+    let actual_content = fs::read_to_string(
+        generate_path("tests-out/docs/A.ts")
+    ).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -99,6 +99,7 @@ struct G {
 fn generate_path(path: &str) -> PathBuf {
     std::env::current_dir().unwrap()
         .join(std::env::var("TS_RS_EXPORT_DIR").unwrap_or_default())
+        .join("tests-out/docs/")
         .join(path)
 }
 
@@ -143,9 +144,9 @@ fn export_a() {
         )
     };
 
-    let actual_content = fs::read_to_string(
-        generate_path("tests-out/docs/A.ts")
-    ).unwrap();
+    let Ok(actual_content) = fs::read_to_string(generate_path("A.ts")) else {
+        panic!("failed to read path: {}", generate_path("A.ts").to_string_lossy())
+    };
 
     assert_eq!(actual_content, expected_content);
 }
@@ -191,7 +192,7 @@ fn export_b() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/B.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("B.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -224,7 +225,7 @@ fn export_c() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/C.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("C.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -256,7 +257,7 @@ fn export_d() {
             "export type D = null;"
         )
     };
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/D.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("D.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -289,7 +290,7 @@ fn export_e() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/E.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("E.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -337,7 +338,7 @@ fn export_f() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/F.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("F.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -385,7 +386,7 @@ fn export_g() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("tests-out/docs/G.ts")).unwrap();
+    let actual_content = fs::read_to_string(generate_path("G.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -145,7 +145,12 @@ fn export_a() {
     };
 
     let Ok(actual_content) = fs::read_to_string(generate_path("A.ts")) else {
-        panic!("failed to read path: {}", generate_path("A.ts").to_string_lossy())
+        panic!(
+            "failed to read path: {}\ncurrent dir: {}\nTS_RS_EXPORT_DIR: {}",
+            generate_path("A.ts").to_string_lossy(),
+            std::env::current_dir().unwrap().to_string_lossy(),
+            std::env::var("TS_RS_EXPORT_DIR").unwrap_or_default()
+        )
     };
 
     assert_eq!(actual_content, expected_content);

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{concat, fs, path::PathBuf};
+use std::{concat, fs};
 
 use ts_rs::TS;
 
@@ -96,13 +96,6 @@ struct G {
 
 /* ============================================================================================== */
 
-fn generate_path(path: &str) -> PathBuf {
-    std::env::current_dir().unwrap()
-        .join(std::env::var("TS_RS_EXPORT_DIR").unwrap_or_default())
-        .join("tests-out/docs/")
-        .join(path)
-}
-
 #[test]
 fn export_a() {
     A::export().unwrap();
@@ -144,14 +137,7 @@ fn export_a() {
         )
     };
 
-    let Ok(actual_content) = fs::read_to_string(generate_path("A.ts")) else {
-        panic!(
-            "failed to read path: {}\ncurrent dir: {}\nTS_RS_EXPORT_DIR: {}",
-            generate_path("A.ts").to_string_lossy(),
-            std::env::current_dir().unwrap().to_string_lossy(),
-            std::env::var("TS_RS_EXPORT_DIR").unwrap_or_default()
-        )
-    };
+    let actual_content = fs::read_to_string(A::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -197,7 +183,7 @@ fn export_b() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("B.ts")).unwrap();
+    let actual_content = fs::read_to_string(B::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -230,7 +216,7 @@ fn export_c() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("C.ts")).unwrap();
+    let actual_content = fs::read_to_string(C::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -262,7 +248,7 @@ fn export_d() {
             "export type D = null;"
         )
     };
-    let actual_content = fs::read_to_string(generate_path("D.ts")).unwrap();
+    let actual_content = fs::read_to_string(D::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -295,7 +281,7 @@ fn export_e() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("E.ts")).unwrap();
+    let actual_content = fs::read_to_string(E::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -343,7 +329,7 @@ fn export_f() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("F.ts")).unwrap();
+    let actual_content = fs::read_to_string(F::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -391,7 +377,7 @@ fn export_g() {
         )
     };
 
-    let actual_content = fs::read_to_string(generate_path("G.ts")).unwrap();
+    let actual_content = fs::read_to_string(G::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -4,7 +4,6 @@ use std::{concat, fs};
 
 use ts_rs::TS;
 
-const PATH: Option<&str> = std::option_env!("TS_RS_EXPORT_DIR");
 
 /* ============================================================================================== */
 
@@ -98,13 +97,11 @@ struct G {
 /* ============================================================================================== */
 
 fn generate_path(path: &str) -> String {
-    format!(
-        "{}{path}",
-        PATH
-            .map(|x| x.trim_end_matches('/'))
-            .map(|x| format!("{x}/"))
-            .unwrap_or_default()
-    )
+    let base = std::env::var("TS_RS_EXPORT_DIR").ok()
+        .map(|x| x.trim_end_matches('/').to_owned())
+        .map(|x| format!("{x}/"))
+        .unwrap_or_default();
+    format!("{base}{path}")
 }
 
 #[test]
@@ -196,7 +193,7 @@ fn export_b() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/B.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/B.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -229,7 +226,7 @@ fn export_c() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/C.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/C.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -261,7 +258,7 @@ fn export_d() {
             "export type D = null;"
         )
     };
-    let actual_content = fs::read_to_string("tests-out/docs/D.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/D.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -294,7 +291,7 @@ fn export_e() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/E.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/E.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -342,7 +339,7 @@ fn export_f() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/F.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/F.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -390,7 +387,7 @@ fn export_g() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/docs/G.ts").unwrap();
+    let actual_content = fs::read_to_string(generate_path("tests-out/docs/G.ts")).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -2,7 +2,7 @@
 
 use std::{concat, fs};
 
-use ts_rs::TS;
+use ts_rs::{output_path, TS};
 
 #[derive(TS)]
 #[ts(export_to = "tests-out/export_manually/UserFile.ts")]
@@ -36,7 +36,7 @@ fn export_manually() {
         )
     };
 
-    let actual_content = fs::read_to_string(User::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<User>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -57,7 +57,7 @@ fn export_manually_dir() {
         )
     };
 
-    let actual_content = fs::read_to_string(UserDir::export_path().unwrap()).unwrap();
+    let actual_content = fs::read_to_string(output_path::<UserDir>().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -36,12 +36,7 @@ fn export_manually() {
         )
     };
 
-    let actual_content = fs::read_to_string(
-        match std::env::var("TS_RS_EXPORT_DIR") {
-            Ok(path) => format!("{}/tests-out/export_manually/UserFile.ts", path.trim_end_matches('/')),
-            Err(_) => "tests-out/export_manually/UserFile.ts".to_owned(),
-        }
-    ).unwrap();
+    let actual_content = fs::read_to_string(User::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -62,12 +57,7 @@ fn export_manually_dir() {
         )
     };
 
-    let actual_content = fs::read_to_string(
-        match std::env::var("TS_RS_EXPORT_DIR") {
-            Ok(path) => format!("{}/tests-out/export_manually/dir/UserDir.ts", path.trim_end_matches('/')),
-            Err(_) => "tests-out/export_manually/dir/UserDir.ts".to_owned(),
-        }
-    ).unwrap();
+    let actual_content = fs::read_to_string(UserDir::export_path().unwrap()).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -36,7 +36,12 @@ fn export_manually() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/export_manually/UserFile.ts").unwrap();
+    let actual_content = fs::read_to_string(
+        match std::env::var("TS_RS_EXPORT_DIR") {
+            Ok(path) => format!("{}/tests-out/export_manually/UserFile.ts", path.trim_end_matches('/')),
+            Err(_) => "tests-out/export_manually/UserFile.ts".to_owned(),
+        }
+    ).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }
@@ -57,7 +62,12 @@ fn export_manually_dir() {
         )
     };
 
-    let actual_content = fs::read_to_string("tests-out/export_manually/dir/UserDir.ts").unwrap();
+    let actual_content = fs::read_to_string(
+        match std::env::var("TS_RS_EXPORT_DIR") {
+            Ok(path) => format!("{}/tests-out/export_manually/dir/UserDir.ts", path.trim_end_matches('/')),
+            Err(_) => "tests-out/export_manually/dir/UserDir.ts".to_owned(),
+        }
+    ).unwrap();
 
     assert_eq!(actual_content, expected_content);
 }

--- a/ts-rs/tests/imports.rs
+++ b/ts-rs/tests/imports.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+use std::path::Path;
+
 use ts_rs::TS;
 
 #[derive(TS)]
@@ -25,7 +27,14 @@ pub enum TestEnum {
 fn test_def() {
     // The only way to get access to how the imports look is to export the type and load the exported file
     TestEnum::export().unwrap();
-    let text = std::fs::read_to_string(TestEnum::EXPORT_TO.unwrap()).unwrap();
+    let path = std::env::var("TS_RS_EXPORT_DIR")
+        .ok()
+        .as_deref()
+        .map(Path::new)
+        .unwrap_or_else(|| Path::new("."))
+        .to_owned()
+        .join(TestEnum::EXPORT_TO.unwrap());
+    let text = std::fs::read_to_string(&path).unwrap();
 
     let expected = match (cfg!(feature = "format"), cfg!(feature = "import-esm")) {
         (true, true) => concat!(
@@ -65,5 +74,5 @@ fn test_def() {
     };
 
     assert_eq!(text, expected);
-    std::fs::remove_file(TestEnum::EXPORT_TO.unwrap()).unwrap();
+    std::fs::remove_file(path).unwrap();
 }

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use ts_rs::TS;
+use ts_rs::{TS, output_path};
 
 #[derive(TS)]
 #[ts(export, export_to = "../ts-rs/tests-out/path_bug/")]
@@ -17,6 +17,6 @@ struct Bar {
 fn path_bug() {
     export_bindings_foo();
 
-    assert!(Foo::export_path().unwrap().is_file());
-    assert!(Bar::export_path().unwrap().is_file());
+    assert!(output_path::<Foo>().unwrap().is_file());
+    assert!(output_path::<Bar>().unwrap().is_file());
 }

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -15,10 +15,11 @@ struct Bar {
 
 #[test]
 fn path_bug() {
-    Foo::export().unwrap();
-    Bar::export().unwrap();
+    export_bindings_foo();
 
-    let base = std::env::current_dir().unwrap();
-    assert!(base.join("./tests-out/path_bug/Foo.ts").is_file());
-    assert!(base.join("./tests-out/path_bug/aaa/Bar.ts").is_file());
+    let base = std::env::current_dir()
+        .unwrap()
+        .join(std::env::var("TS_RS_EXPORT_DIR").unwrap_or("".to_owned()));
+    assert!(base.join("../ts-rs/tests-out/path_bug/Foo.ts").is_file());
+    assert!(base.join("tests-out/path_bug/aaa/Bar.ts").is_file());
 }

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -17,9 +17,6 @@ struct Bar {
 fn path_bug() {
     export_bindings_foo();
 
-    let base = std::env::current_dir()
-        .unwrap()
-        .join(std::env::var("TS_RS_EXPORT_DIR").unwrap_or("".to_owned()));
-    assert!(base.join("../ts-rs/tests-out/path_bug/Foo.ts").is_file());
-    assert!(base.join("tests-out/path_bug/aaa/Bar.ts").is_file());
+    assert!(Foo::export_path().unwrap().is_file());
+    assert!(Bar::export_path().unwrap().is_file());
 }


### PR DESCRIPTION
As discussed in #245, when using both `TS_RS_EXPORT_DIR` and `#[ts(export_to = "...")]`, the `export_to` path should be relative to `TS_RS_EXPORT_DIR` instead of the project's `Cargo.toml`