### PR TITLE
Improve location of some compiler errors

### DIFF
--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -89,3 +89,11 @@ fn parse_assign_str(input: ParseStream) -> Result<String> {
 fn parse_assign_inflection(input: ParseStream) -> Result<Inflection> {
     parse_assign_str(input).and_then(Inflection::try_from)
 }
+
+fn parse_assign_from_str<T>(input: ParseStream) -> Result<T> where T: Parse {
+    input.parse::<Token![=]>()?;
+    match Lit::parse(input)? {
+        Lit::Str(string) => string.parse(),
+        other => Err(Error::new(other.span(), "expected string")),
+    }
+}

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -116,7 +116,7 @@ fn format_variant(
                     quote!(format!("{{ \"{}\": \"{}\" }}", #tag, #name))
                 } else {
                     let ty = match (type_override, type_as) {
-                        (Some(_), Some(_)) => syn_err!("`type` is not compatible with `as`"),
+                        (Some(_), Some(_)) => syn_err_spanned!(variant; "`type` is not compatible with `as`"),
                         (Some(type_override), None) => quote! { #type_override },
                         (None, Some(type_as)) => {
                             quote!(<#type_as as ts_rs::TS>::name())
@@ -165,7 +165,7 @@ fn format_variant(
                         quote!(format!("{{ \"{}\": \"{}\" }}", #tag, #name))
                     } else {
                         let ty = match (type_override, type_as) {
-                            (Some(_), Some(_)) => syn_err!("`type` is not compatible with `as`"),
+                            (Some(_), Some(_)) => syn_err_spanned!(variant; "`type` is not compatible with `as`"),
                             (Some(type_override), None) => quote! { #type_override },
                             (None, Some(type_as)) => {
                                 quote!(<#type_as as ts_rs::TS>::name())

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Fields, Generics, ItemEnum, Type, Variant};
+use syn::{Fields, Generics, ItemEnum, Variant};
 
 use crate::{
     attr::{EnumAttr, FieldAttr, StructAttr, Tagged, VariantAttr},
@@ -119,8 +119,7 @@ fn format_variant(
                         (Some(_), Some(_)) => syn_err!("`type` is not compatible with `as`"),
                         (Some(type_override), None) => quote! { #type_override },
                         (None, Some(type_as)) => {
-                            let ty = syn::parse_str::<Type>(&type_as)?;
-                            quote!(<#ty as ts_rs::TS>::name())
+                            quote!(<#type_as as ts_rs::TS>::name())
                         }
                         (None, None) => {
                             let ty = &unnamed.unnamed[0].ty;
@@ -169,8 +168,7 @@ fn format_variant(
                             (Some(_), Some(_)) => syn_err!("`type` is not compatible with `as`"),
                             (Some(type_override), None) => quote! { #type_override },
                             (None, Some(type_as)) => {
-                                let ty = syn::parse_str::<Type>(&type_as)?;
-                                quote!(<#ty as ts_rs::TS>::name())
+                                quote!(<#type_as as ts_rs::TS>::name())
                             }
                             (None, None) => {
                                 let ty = &unnamed.unnamed[0].ty;

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{Field, FieldsNamed, GenericArgument, Generics, PathArguments, Result, Type};
+use quote::{quote, ToTokens};
+use syn::{spanned::Spanned, Field, FieldsNamed, GenericArgument, Generics, PathArguments, Result, Type};
 
 use crate::{
     attr::{FieldAttr, Inflection, Optional, StructAttr},
@@ -93,11 +93,11 @@ fn format_field(
     }
 
     if type_as.is_some() && type_override.is_some() {
-        syn_err!("`type` is not compatible with `as`")
+        syn_err!(field.ident.span(); "`type` is not compatible with `as`")
     }
 
     let parsed_ty = if let Some(ref type_as) = type_as {
-        syn::parse_str::<Type>(type_as)?
+        syn::parse_str::<Type>(&type_as.to_token_stream().to_string())?
     } else {
         field.ty.clone()
     };
@@ -120,10 +120,10 @@ fn format_field(
 
     if flatten {
         match (&type_as, &type_override, &rename, inline) {
-            (Some(_), _, _, _) => syn_err!("`as` is not compatible with `flatten`"),
-            (_, Some(_), _, _) => syn_err!("`type` is not compatible with `flatten`"),
-            (_, _, Some(_), _) => syn_err!("`rename` is not compatible with `flatten`"),
-            (_, _, _, true) => syn_err!("`inline` is not compatible with `flatten`"),
+            (Some(_), _, _, _) => syn_err!(field.ident.span(); "`as` is not compatible with `flatten`"),
+            (_, Some(_), _, _) => syn_err!(field.ident.span(); "`type` is not compatible with `flatten`"),
+            (_, _, Some(_), _) => syn_err!(field.ident.span(); "`rename` is not compatible with `flatten`"),
+            (_, _, _, true) => syn_err!(field.ident.span(); "`inline` is not compatible with `flatten`"),
             _ => {}
         }
 
@@ -175,12 +175,12 @@ fn extract_option_argument(ty: &Type) -> Result<&Type> {
                 PathArguments::AngleBracketed(args) if args.args.len() == 1 => {
                     match &args.args[0] {
                         GenericArgument::Type(inner_ty) => Ok(inner_ty),
-                        _ => syn_err!("`Option` argument must be a type"),
+                        other => syn_err!(other.span(); "`Option` argument must be a type"),
                     }
                 }
-                _ => syn_err!("`Option` type must have a single generic argument"),
+                other => syn_err!(other.span(); "`Option` type must have a single generic argument"),
             }
         }
-        _ => syn_err!("`optional` can only be used on an Option<T> type"),
+        other => syn_err!(other.span(); "`optional` can only be used on an Option<T> type"),
     }
 }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -93,7 +93,7 @@ fn format_field(
     }
 
     if type_as.is_some() && type_override.is_some() {
-        syn_err!(field.ident.span(); "`type` is not compatible with `as`")
+        syn_err_spanned!(field; "`type` is not compatible with `as`")
     }
 
     let parsed_ty = if let Some(ref type_as) = type_as {
@@ -120,10 +120,10 @@ fn format_field(
 
     if flatten {
         match (&type_as, &type_override, &rename, inline) {
-            (Some(_), _, _, _) => syn_err!(field.ident.span(); "`as` is not compatible with `flatten`"),
-            (_, Some(_), _, _) => syn_err!(field.ident.span(); "`type` is not compatible with `flatten`"),
-            (_, _, Some(_), _) => syn_err!(field.ident.span(); "`rename` is not compatible with `flatten`"),
-            (_, _, _, true) => syn_err!(field.ident.span(); "`inline` is not compatible with `flatten`"),
+            (Some(_), _, _, _) => syn_err_spanned!(field; "`as` is not compatible with `flatten`"),
+            (_, Some(_), _, _) => syn_err_spanned!(field; "`type` is not compatible with `flatten`"),
+            (_, _, Some(_), _) => syn_err_spanned!(field; "`rename` is not compatible with `flatten`"),
+            (_, _, _, true) => syn_err_spanned!(field; "`inline` is not compatible with `flatten`"),
             _ => {}
         }
 

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -32,15 +32,15 @@ pub(crate) fn newtype(
     } = FieldAttr::from_attrs(&inner.attrs)?;
 
     match (&rename_inner, skip, optional.optional, flatten) {
-        (Some(_), ..) => syn_err!("`rename` is not applicable to newtype fields"),
+        (Some(_), ..) => syn_err_spanned!(fields; "`rename` is not applicable to newtype fields"),
         (_, true, ..) => return super::unit::null(attr, name, generics.clone()),
-        (_, _, true, ..) => syn_err!("`optional` is not applicable to newtype fields"),
-        (_, _, _, true) => syn_err!("`flatten` is not applicable to newtype fields"),
+        (_, _, true, ..) => syn_err_spanned!(fields; "`optional` is not applicable to newtype fields"),
+        (_, _, _, true) => syn_err_spanned!(fields; "`flatten` is not applicable to newtype fields"),
         _ => {}
     };
 
     if type_as.is_some() && type_override.is_some() {
-        syn_err!("`type` is not compatible with `as`")
+        syn_err_spanned!(fields; "`type` is not compatible with `as`")
     }
 
     let inner_ty = if let Some(ref type_as) = type_as {

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{FieldsUnnamed, Generics, Result, Type};
 
 use crate::{
@@ -44,7 +44,7 @@ pub(crate) fn newtype(
     }
 
     let inner_ty = if let Some(ref type_as) = type_as {
-        syn::parse_str::<Type>(type_as)?
+        syn::parse_str::<Type>(&type_as.to_token_stream().to_string())?
     } else {
         inner.ty.clone()
     };

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Field, FieldsUnnamed, Generics, Result, Type, spanned::Spanned};
+use syn::{Field, FieldsUnnamed, Generics, Result, Type};
 
 use crate::{
     attr::{FieldAttr, StructAttr},
@@ -72,19 +72,19 @@ fn format_field(
     };
 
     if type_as.is_some() && type_override.is_some() {
-        syn_err!(field.ty.span(); "`type` is not compatible with `as`")
+        syn_err_spanned!(field; "`type` is not compatible with `as`")
     }
 
     if rename.is_some() {
-        syn_err!(field.ty.span(); "`rename` is not applicable to tuple structs")
+        syn_err_spanned!(field; "`rename` is not applicable to tuple structs")
     }
 
     if optional.optional {
-        syn_err!(field.ty.span(); "`optional` is not applicable to tuple fields")
+        syn_err_spanned!(field; "`optional` is not applicable to tuple fields")
     }
 
     if flatten {
-        syn_err!(field.ty.span(); "`flatten` is not applicable to tuple fields")
+        syn_err_spanned!(field; "`flatten` is not applicable to tuple fields")
     }
 
     formatted_fields.push(match type_override {

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::{Field, FieldsUnnamed, Generics, Result, Type};
+use quote::{quote, ToTokens};
+use syn::{Field, FieldsUnnamed, Generics, Result, Type, spanned::Spanned};
 
 use crate::{
     attr::{FieldAttr, StructAttr},
@@ -66,25 +66,25 @@ fn format_field(
     }
 
     let ty = if let Some(ref type_as) = type_as {
-        syn::parse_str::<Type>(type_as)?
+        syn::parse_str::<Type>(&type_as.to_token_stream().to_string())?
     } else {
         field.ty.clone()
     };
 
     if type_as.is_some() && type_override.is_some() {
-        syn_err!("`type` is not compatible with `as`")
+        syn_err!(field.ty.span(); "`type` is not compatible with `as`")
     }
 
     if rename.is_some() {
-        syn_err!("`rename` is not applicable to tuple structs")
+        syn_err!(field.ty.span(); "`rename` is not applicable to tuple structs")
     }
 
     if optional.optional {
-        syn_err!("`optional` is not applicable to tuple fields")
+        syn_err!(field.ty.span(); "`optional` is not applicable to tuple fields")
     }
 
     if flatten {
-        syn_err!("`flatten` is not applicable to tuple fields")
+        syn_err!(field.ty.span(); "`flatten` is not applicable to tuple fields")
     }
 
     formatted_fields.push(match type_override {

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -17,6 +17,12 @@ macro_rules! syn_err {
     };
 }
 
+macro_rules! syn_err_spanned {
+    ($s:expr; $l:literal $(, $a:expr)*) => {
+        return Err(syn::Error::new_spanned($s, format!($l $(, $a)*)))
+    };
+}
+
 macro_rules! impl_parse {
     ($i:ident ($input:ident, $out:ident) { $($k:pat => $e:expr),* $(,)? }) => {
         impl std::convert::TryFrom<&syn::Attribute> for $i {


### PR DESCRIPTION
This PR improves where the compiler error points when there is an attribute error.

This errors now point at the exact location they should
- The `#[ts(as = "...")]` attribute would point at the token after the string when receiving invalid path syntax
- The `#[ts(optional = nullable)]` would do the same when receiving anything other than `nullable`

Errors about incompatible attributes point at the entire field definition
