### PR TITLE
Add dependency caching to GH Actions for faster CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            e2e/dependencies/consumer/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/dependencies/consumer/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
         run: |
@@ -39,15 +31,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            e2e/workspace/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/workspace/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: workspace e2e test
         working-directory: e2e/workspace
         run: |
@@ -71,15 +55,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            example/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('example/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: example e2e test
         working-directory: example
         run: |
@@ -101,6 +77,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v2
       - name: Check that README.md is up-to-date
         working-directory: ts-rs
         run: |
@@ -116,15 +93,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: |
           cargo test --all-features
@@ -141,15 +110,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
@@ -166,15 +127,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: |
           cargo test --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             e2e/dependencies/consumer/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/dependencies/consumer/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/dependencies/consumer/Cargo.lock') }}
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
         run: |
@@ -47,7 +47,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             e2e/workspace/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/workspace/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/workspace/Cargo.lock') }}
       - name: workspace e2e test
         working-directory: e2e/workspace
         run: |
@@ -79,7 +79,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             example/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('example/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('example/Cargo.lock') }}
       - name: example e2e test
         working-directory: example
         run: |
@@ -124,7 +124,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Test
         run: |
           cargo test --all-features
@@ -149,7 +149,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Test
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
@@ -174,7 +174,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Test
         run: |
           cargo test --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: All features
+        run: |
+          cargo test --all-features
+          shopt -s globstar
+          tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
+          rm -rf ts-rs/bindings
       - name: Test with export env
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
@@ -140,10 +146,4 @@ jobs:
           cargo test --no-default-features
           shopt -s globstar
           tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals
-          rm -rf ts-rs/bindings
-      - name: All features
-        run: |
-          cargo test --all-features
-          shopt -s globstar
-          tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
   test-no-features:
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name !! github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   e2e-dependencies:
     name: Run 'dependencies' end-to-end test
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -33,7 +33,7 @@ jobs:
   e2e-workspace:
     name: Run 'workspace' end-to-end test
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -65,7 +65,7 @@ jobs:
   e2e-example:
     name: End-to-end test example
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -95,7 +95,7 @@ jobs:
   readme-up-to-date:
     name: Check that README.md is up-to-date
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -119,7 +119,7 @@ jobs:
   test-all-features:
     name: Test ts-rs with --all-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -144,7 +144,7 @@ jobs:
   test-export-env:
     name: Test ts-rs with TS_RS_EXPORT_DIR
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -169,7 +169,7 @@ jobs:
   test-no-features:
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            e2e/dependencies/consumer/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
@@ -46,7 +46,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            e2e/workspace/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: workspace e2e test
         working-directory: e2e/workspace
@@ -78,7 +78,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            example/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: example e2e test
         working-directory: example
@@ -108,7 +108,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            ts-rs/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check that README.md is up-to-date
         working-directory: ts-rs
@@ -132,7 +132,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            ts-ts/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |
@@ -157,7 +157,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            ts-rs/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |
@@ -182,7 +182,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            ts-rs/target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,16 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
 name: Test
 jobs:
   e2e-dependencies:
     name: Run 'dependencies' end-to-end test
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -31,7 +38,7 @@ jobs:
           tsc custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
   e2e-workspace:
     name: Run 'workspace' end-to-end test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latestif: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -63,6 +70,7 @@ jobs:
   e2e-example:
     name: End-to-end test example
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -92,6 +100,7 @@ jobs:
   readme-up-to-date:
     name: Check that README.md is up-to-date
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -115,6 +124,7 @@ jobs:
   test-all-features:
     name: Test ts-rs with --all-features
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -137,9 +147,9 @@ jobs:
           rm -rf ts-rs/bindings
 
   test-export-env:
-    needs: test-all-features
     name: Test ts-rs with TS_RS_EXPORT_DIR
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -162,9 +172,9 @@ jobs:
           rm -rf ts-rs/output
 
   test-no-features:
-    needs: test-export-env
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
-        working-directory: e2e/dependencies/consumer
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            e2e/dependencies/consumer/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/dependencies/consumer/**/Cargo.lock') }}
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
         run: |
@@ -41,15 +40,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
-        working-directory: e2e/workspace
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            e2e/workspace/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('e2e/workspace/**/Cargo.lock') }}
       - name: workspace e2e test
         working-directory: e2e/workspace
         run: |
@@ -74,15 +72,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
-        working-directory: example
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            example/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('example/**/Cargo.lock') }}
       - name: example e2e test
         working-directory: example
         run: |
@@ -104,15 +101,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check that README.md is up-to-date
         working-directory: ts-rs
         run: |
@@ -136,7 +124,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
       - name: Test
         run: |
           cargo test --all-features
@@ -161,7 +149,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
       - name: Test
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
@@ -186,7 +174,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('ts-rs/**/Cargo.lock') }}
       - name: Test
         run: |
           cargo test --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,8 @@ jobs:
           cargo install cargo-readme 
           diff -u ../README.md <(cargo readme)
 
-  test:
-    name: Test ts-rs
+  test-all-features:
+    name: Test ts-rs with --all-features
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -129,19 +129,55 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: All features
+      - name: Test
         run: |
           cargo test --all-features
           shopt -s globstar
           tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/bindings
-      - name: Test with export env
+
+  test-export-env:
+    name: Test ts-rs with TS_RS_EXPORT_DIR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Test
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
           shopt -s globstar
           tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/output
-      - name: No features
+
+  test-no-features:
+    name: Test ts-rs with --no-default-features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Test
         run: |
           cargo test --no-default-features
           shopt -s globstar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
         run: |
@@ -28,6 +37,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: workspace e2e test
         working-directory: e2e/workspace
         run: |
@@ -50,6 +68,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: example e2e test
         working-directory: example
         run: |
@@ -70,6 +97,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check that README.md is up-to-date
         working-directory: ts-rs
         run: |
@@ -84,6 +120,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test with export env
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,10 @@
-on:
-  push:
-    branches:
-    - '**'
-  pull_request:
-    branches:
-    - '**'
+on: [push, pull_request]
 name: Test
 jobs:
   e2e-dependencies:
     name: Run 'dependencies' end-to-end test
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -38,7 +32,7 @@ jobs:
           tsc custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
   e2e-workspace:
     name: Run 'workspace' end-to-end test
-    runs-on: ubuntu-latestif: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latestif: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -70,7 +64,7 @@ jobs:
   e2e-example:
     name: End-to-end test example
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -100,7 +94,7 @@ jobs:
   readme-up-to-date:
     name: Check that README.md is up-to-date
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -124,7 +118,7 @@ jobs:
   test-all-features:
     name: Test ts-rs with --all-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -149,7 +143,7 @@ jobs:
   test-export-env:
     name: Test ts-rs with TS_RS_EXPORT_DIR
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -174,7 +168,7 @@ jobs:
   test-no-features:
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name !! github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,8 @@ jobs:
           tsc custom-bindings/**/*.ts --noEmit --noUnusedLocals --strict
   e2e-workspace:
     name: Run 'workspace' end-to-end test
-    runs-on: ubuntu-latestif: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    runs-on: ubuntu-latest
+    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-      steps:
+    steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
+        working-directory: e2e/dependencies/consumer
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            e2e/dependencies/consumer/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: dependencies e2e test
         working-directory: e2e/dependencies/consumer
@@ -40,13 +41,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
+        working-directory: e2e/workspace
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            e2e/workspace/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: workspace e2e test
         working-directory: e2e/workspace
@@ -72,13 +74,14 @@ jobs:
         with:
           toolchain: stable
       - uses: actions/cache@v3
+        working-directory: example
         with:
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            example/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: example e2e test
         working-directory: example
@@ -108,7 +111,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ts-rs/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Check that README.md is up-to-date
         working-directory: ts-rs
@@ -132,7 +135,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ts-ts/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |
@@ -157,7 +160,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ts-rs/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |
@@ -182,7 +185,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ts-rs/target/
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           cargo test --all-features
           shopt -s globstar
-          tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
+          tsc ts-rs/bindings/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/bindings
 
   test-export-env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   e2e-dependencies:
     name: Run 'dependencies' end-to-end test
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -33,7 +33,7 @@ jobs:
   e2e-workspace:
     name: Run 'workspace' end-to-end test
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -65,7 +65,7 @@ jobs:
   e2e-example:
     name: End-to-end test example
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -95,7 +95,7 @@ jobs:
   readme-up-to-date:
     name: Check that README.md is up-to-date
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -119,7 +119,7 @@ jobs:
   test-all-features:
     name: Test ts-rs with --all-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -144,7 +144,7 @@ jobs:
   test-export-env:
     name: Test ts-rs with TS_RS_EXPORT_DIR
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -169,8 +169,8 @@ jobs:
   test-no-features:
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
-    if: github.event_name != "pull_request" || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    steps:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,7 @@ jobs:
           rm -rf ts-rs/bindings
 
   test-export-env:
+    needs: test-all-features
     name: Test ts-rs with TS_RS_EXPORT_DIR
     runs-on: ubuntu-latest
     steps:
@@ -161,6 +162,7 @@ jobs:
           rm -rf ts-rs/output
 
   test-no-features:
+    needs: test-export-env
     name: Test ts-rs with --no-default-features
     runs-on: ubuntu-latest
     steps:

--- a/e2e/dependencies/consumer/src/main.rs
+++ b/e2e/dependencies/consumer/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use ts_rs::TS;
 use dependency1::*;
 

--- a/e2e/dependencies/consumer/src/main.rs
+++ b/e2e/dependencies/consumer/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use ts_rs::TS;
 use dependency1::*;
+use ts_rs::TS;
 
 #[derive(TS)]
 #[ts(export)]
@@ -21,8 +21,7 @@ struct T0;
 #[derive(TS)]
 #[ts(export)]
 struct T1 {
-    t0: Option<T0>
+    t0: Option<T0>,
 }
-
 
 fn main() {}

--- a/e2e/dependencies/dependency1/src/lib.rs
+++ b/e2e/dependencies/dependency1/src/lib.rs
@@ -2,12 +2,12 @@ use ts_rs::TS;
 
 #[derive(TS)]
 pub struct LibraryType1 {
-    pub a: i32
+    pub a: i32,
 }
 
 #[derive(TS)]
 pub struct LibraryType2<T> {
-    pub t: T
+    pub t: T,
 }
 
 #[derive(TS)]

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -38,7 +38,7 @@ struct User {
     gender: Gender,
     token: Uuid,
     #[ts(type = "string")]
-    created_at: NaiveDateTime
+    created_at: NaiveDateTime,
 }
 
 #[derive(Serialize, TS)]

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -38,7 +38,7 @@ struct User {
     gender: Gender,
     token: Uuid,
     #[ts(type = "string")]
-    created_at: NaiveDateTime,
+    created_at: NaiveDateTime
 }
 
 #[derive(Serialize, TS)]


### PR DESCRIPTION
Our CI takes quite a while to run, mostly because of the Rust compiler being kinda slow. This PR attempts to remedy that by caching its dependencies. It also runs twice on every commit when we do PR's from within the repo, this PR also fixes that.

I have no idea if it will actually work, but should be worth the shot