### PR TITLE
Reduce test nesting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,17 +88,17 @@ jobs:
         run: |
           TS_RS_EXPORT_DIR=output cargo test --no-default-features
           shopt -s globstar
-          tsc ts-rs/output/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
+          tsc ts-rs/output/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/output
       - name: No features
         run: |
           cargo test --no-default-features
           shopt -s globstar
-          tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals
+          tsc ts-rs/bindings/**/*.ts --noEmit --noUnusedLocals
           rm -rf ts-rs/bindings
       - name: All features
         run: |
           cargo test --all-features
           shopt -s globstar
-          tsc ts-rs/bindings/tests-out/**/*.ts --noEmit --noUnusedLocals --strict
+          tsc ts-rs/bindings/**/*.ts --noEmit --noUnusedLocals --strict
           rm -rf ts-rs/bindings

--- a/ts-rs/tests/arrays.rs
+++ b/ts-rs/tests/arrays.rs
@@ -3,7 +3,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/arrays/")]
+#[ts(export, export_to = "arrays/")]
 struct Interface {
     a: [i32; 4],
 }

--- a/ts-rs/tests/chrono.rs
+++ b/ts-rs/tests/chrono.rs
@@ -8,7 +8,7 @@ use chrono::{
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/chrono/")]
+#[ts(export, export_to = "chrono/")]
 struct Chrono {
     date: (NaiveDate, Date<Utc>, Date<Local>, Date<FixedOffset>),
     time: NaiveTime,

--- a/ts-rs/tests/docs.rs
+++ b/ts-rs/tests/docs.rs
@@ -11,7 +11,7 @@ use ts_rs::TS;
 ///
 /// Testing
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 struct A {
     /// Doc of field
     ///
@@ -20,7 +20,7 @@ struct A {
 }
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 /// Doc comment.
 /// Supports new lines.
 ///
@@ -33,7 +33,7 @@ struct B {
 }
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 /// Doc comment.
 /// Supports new lines.
 ///
@@ -41,7 +41,7 @@ struct B {
 struct C {}
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 /// Doc comment.
 /// Supports new lines.
 ///
@@ -49,7 +49,7 @@ struct C {}
 struct D;
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 /// Doc comment.
 /// Supports new lines.
 ///
@@ -57,7 +57,7 @@ struct D;
 enum E {}
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 /// Doc comment.
 /// Supports new lines.
 ///
@@ -83,7 +83,7 @@ enum F {
 }
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/docs/")]
+#[ts(export_to = "docs/")]
 struct G {
     /// Docs
     some_other_field: i32,

--- a/ts-rs/tests/enum_flattening.rs
+++ b/ts-rs/tests/enum_flattening.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/enum_flattening/externally_tagged/")]
+#[ts(export, export_to = "enum_flattening/externally_tagged/")]
 struct FooExternally {
     qux: i32,
     #[cfg_attr(feature = "serde-compat", serde(flatten))]
@@ -17,7 +17,7 @@ struct FooExternally {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/enum_flattening/externally_tagged/")]
+#[ts(export, export_to = "enum_flattening/externally_tagged/")]
 enum BarExternally {
     Baz { a: i32, a2: String },
     Biz { b: bool },
@@ -33,7 +33,7 @@ fn externally_tagged() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/adjacently_tagged/")]
+#[ts(export, export_to = "enum_flattening/adjacently_tagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 struct FooAdjecently {
     one: i32,
@@ -44,7 +44,7 @@ struct FooAdjecently {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/adjacently_tagged/")]
+#[ts(export, export_to = "enum_flattening/adjacently_tagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type", content = "stuff"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type", content = "stuff"))]
@@ -74,7 +74,7 @@ fn adjacently_tagged() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/internally_tagged/")]
+#[ts(export, export_to = "enum_flattening/internally_tagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 struct FooInternally {
     qux: Option<String>,
@@ -85,7 +85,7 @@ struct FooInternally {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/internally_tagged/")]
+#[ts(export, export_to = "enum_flattening/internally_tagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
@@ -104,7 +104,7 @@ fn internally_tagged() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/untagged/")]
+#[ts(export, export_to = "enum_flattening/untagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 struct FooUntagged {
     #[cfg_attr(feature = "serde-compat", serde(flatten))]
@@ -113,7 +113,7 @@ struct FooUntagged {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_flattening/untagged/")]
+#[ts(export, export_to = "enum_flattening/untagged/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(untagged))]
 #[cfg_attr(not(feature = "serde-compat"), ts(untagged))]

--- a/ts-rs/tests/enum_struct_rename_all.rs
+++ b/ts-rs/tests/enum_struct_rename_all.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_struct_rename_all/")]
+#[ts(export, export_to = "enum_struct_rename_all/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(rename_all = "camelCase"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "camelCase"))]
@@ -30,7 +30,7 @@ pub fn enum_struct_rename_all() {
 }
 
 #[derive(TS, Clone)]
-#[ts(export, export_to = "tests-out/enum_struct_rename_all/")]
+#[ts(export, export_to = "enum_struct_rename_all/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(rename_all_fields = "kebab-case"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(rename_all_fields = "kebab-case"))]

--- a/ts-rs/tests/enum_variant_annotation.rs
+++ b/ts-rs/tests/enum_variant_annotation.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_variant_anotation/")]
+#[ts(export, export_to = "enum_variant_anotation/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(rename_all = "SCREAMING_SNAKE_CASE"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "SCREAMING_SNAKE_CASE"))]
@@ -31,7 +31,7 @@ fn test_enum_variant_rename_all() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_variant_anotation/")]
+#[ts(export, export_to = "enum_variant_anotation/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 enum B {
     #[cfg_attr(feature = "serde-compat", serde(rename = "SnakeMessage"))]
@@ -57,7 +57,7 @@ fn test_enum_variant_rename() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/enum_variant_anotation/")]
+#[ts(export, export_to = "enum_variant_anotation/")]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "kind"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "kind"))]

--- a/ts-rs/tests/export_manually.rs
+++ b/ts-rs/tests/export_manually.rs
@@ -5,7 +5,7 @@ use std::{concat, fs};
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/export_manually/UserFile.ts")]
+#[ts(export_to = "export_manually/UserFile.ts")]
 struct User {
     name: String,
     age: i32,
@@ -13,7 +13,7 @@ struct User {
 }
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/export_manually/dir/")]
+#[ts(export_to = "export_manually/dir/")]
 struct UserDir {
     name: String,
     age: i32,

--- a/ts-rs/tests/flatten.rs
+++ b/ts-rs/tests/flatten.rs
@@ -3,14 +3,14 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/flatten/")]
+#[ts(export, export_to = "flatten/")]
 struct A {
     a: i32,
     b: i32,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/flatten/")]
+#[ts(export, export_to = "flatten/")]
 struct B {
     #[ts(flatten)]
     a: A,
@@ -18,7 +18,7 @@ struct B {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/flatten/")]
+#[ts(export, export_to = "flatten/")]
 struct C {
     #[ts(inline)]
     b: B,

--- a/ts-rs/tests/generic_fields.rs
+++ b/ts-rs/tests/generic_fields.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct Newtype(Vec<Cow<'static, i32>>);
 
 #[test]
@@ -14,7 +14,7 @@ fn newtype() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct NewtypeNested(Vec<Vec<i32>>);
 
 #[test]
@@ -35,7 +35,7 @@ fn alias_nested() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct Struct {
     a: Box<Vec<String>>,
     b: (Vec<String>, Vec<String>),
@@ -51,7 +51,7 @@ fn named() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct StructNested {
     a: Vec<Vec<String>>,
     b: (Vec<Vec<String>>, Vec<Vec<String>>),
@@ -64,7 +64,7 @@ fn named_nested() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct Tuple(Vec<i32>, (Vec<i32>, Vec<i32>), [Vec<i32>; 3]);
 
 #[test]
@@ -76,7 +76,7 @@ fn tuple() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generic_fields/")]
+#[ts(export, export_to = "generic_fields/")]
 struct TupleNested(
     Vec<Vec<i32>>,
     (Vec<Vec<i32>>, Vec<Vec<i32>>),

--- a/ts-rs/tests/generics.rs
+++ b/ts-rs/tests/generics.rs
@@ -10,7 +10,7 @@ use std::{
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct Generic<T>
 where
     T: TS,
@@ -20,14 +20,14 @@ where
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericAutoBound<T> {
     value: T,
     values: Vec<T>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericAutoBound2<T>
 where
     T: PartialEq,
@@ -37,7 +37,7 @@ where
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct Container {
     foo: Generic<u32>,
     bar: Box<HashSet<Generic<u32>>>,
@@ -55,7 +55,7 @@ macro_rules! declare {
 
 declare! {
     #[derive(TS)]
-    #[ts(export, export_to = "tests-out/generics/")]
+    #[ts(export, export_to = "generics/")]
     TypeGroup {
         foo: Vec<Container>,
     }
@@ -90,7 +90,7 @@ fn test() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 enum GenericEnum<A, B, C> {
     A(A),
     B(B, B, B),
@@ -111,7 +111,7 @@ fn generic_enum() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct NewType<T>(Vec<Vec<T>>);
 
 #[test]
@@ -123,7 +123,7 @@ fn generic_newtype() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct Tuple<T>(T, Vec<T>, Vec<Vec<T>>);
 
 #[test]
@@ -135,7 +135,7 @@ fn generic_tuple() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct Struct<T> {
     a: T,
     b: (T, T),
@@ -156,13 +156,13 @@ fn generic_struct() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericInline<T> {
     t: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ContainerInline {
     g: GenericInline<String>,
     #[ts(inline)]
@@ -184,13 +184,13 @@ fn inline() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericWithBounds<T: ToString> {
     t: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ContainerWithBounds {
     g: GenericWithBounds<String>,
 
@@ -214,13 +214,13 @@ fn inline_with_bounds() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericWithDefault<T = String> {
     t: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ContainerWithDefault {
     g: GenericWithDefault<String>,
 
@@ -244,19 +244,19 @@ fn inline_with_default() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ADefault<T = String> {
     t: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct BDefault<U = Option<ADefault<i32>>> {
     u: U,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct YDefault {
     a1: ADefault,
     a2: ADefault<i32>,
@@ -284,17 +284,17 @@ fn default() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ATraitBounds<T: ToString = i32> {
     t: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct BTraitBounds<T: ToString + Debug + Clone + 'static>(T);
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 enum CTraitBounds<T: Copy + Clone + PartialEq, K: Copy + PartialOrd = i32> {
     A { t: T },
     B(T),
@@ -333,31 +333,31 @@ fn trait_bounds() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct T0<T> {
     t0: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct P0<T> {
     p0: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct T1<T> {
     t0: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct P1<T> {
     p0: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct Parent {
     a: T1<T0<u32>>,
     b: T1<P1<T0<P0<u32>>>>,
@@ -365,7 +365,7 @@ struct Parent {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct GenericParent<T> {
     a_t: T1<T0<T>>,
     b_t: T1<P1<T0<P0<T>>>>,
@@ -395,18 +395,18 @@ fn deeply_nested() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct SomeType(String);
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 enum MyEnum<A, B> {
     VariantA(A),
     VariantB(B),
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/generics/")]
+#[ts(export, export_to = "generics/")]
 struct ParentEnum {
     e: MyEnum<i32, i32>,
     #[ts(inline)]

--- a/ts-rs/tests/hashmap.rs
+++ b/ts-rs/tests/hashmap.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct Hashes {
     map: HashMap<String, String>,
     set: HashSet<String>,
@@ -25,7 +25,7 @@ type CustomHashMap<K, V> = HashMap<K, V, CustomHasher>;
 type CustomHashSet<K> = HashSet<K, CustomHasher>;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct HashesHasher {
     map: CustomHashMap<String, String>,
     set: CustomHashSet<String>,
@@ -40,21 +40,21 @@ fn hashmap_with_custom_hasher() {
 }
 
 #[derive(TS, Eq, PartialEq, Hash)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct CustomKey(String);
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct CustomValue;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct HashMapWithCustomTypes {
     map: HashMap<CustomKey, CustomValue>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashmap/")]
+#[ts(export, export_to = "hashmap/")]
 struct BTreeMapWithCustomTypes {
     map: BTreeMap<CustomKey, CustomValue>,
 }

--- a/ts-rs/tests/hashset.rs
+++ b/ts-rs/tests/hashset.rs
@@ -5,17 +5,17 @@ use std::collections::{BTreeSet, HashSet};
 use ts_rs::TS;
 
 #[derive(TS, Eq, PartialEq, Hash)]
-#[ts(export, export_to = "tests-out/hashset/")]
+#[ts(export, export_to = "hashset/")]
 struct CustomValue;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashset/")]
+#[ts(export, export_to = "hashset/")]
 struct HashSetWithCustomType {
     set: HashSet<CustomValue>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/hashset/")]
+#[ts(export, export_to = "hashset/")]
 struct BTreeSetWithCustomType {
     set: BTreeSet<CustomValue>,
 }

--- a/ts-rs/tests/imports.rs
+++ b/ts-rs/tests/imports.rs
@@ -3,19 +3,19 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/imports/ts_rs_test_type_a.ts")]
+#[ts(export, export_to = "imports/ts_rs_test_type_a.ts")]
 pub struct TestTypeA<T> {
     value: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/imports/ts_rs_test_type_b.ts")]
+#[ts(export, export_to = "imports/ts_rs_test_type_b.ts")]
 pub struct TestTypeB<T> {
     value: T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/imports/")]
+#[ts(export, export_to = "imports/")]
 pub enum TestEnum {
     C { value: TestTypeB<i8> },
     A1 { value: TestTypeA<i32> },

--- a/ts-rs/tests/indexmap.rs
+++ b/ts-rs/tests/indexmap.rs
@@ -5,7 +5,7 @@ use indexmap::{IndexMap, IndexSet};
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/indexmap/")]
+#[ts(export, export_to = "indexmap/")]
 struct Indexes {
     map: IndexMap<String, String>,
     set: IndexSet<String>,

--- a/ts-rs/tests/issue-168.rs
+++ b/ts-rs/tests/issue-168.rs
@@ -5,27 +5,27 @@ use std::collections::HashMap;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_168/")]
+#[ts(export, export_to = "issue_168/")]
 pub struct Foo {
     map: HashMap<usize, Bar>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_168/")]
+#[ts(export, export_to = "issue_168/")]
 pub struct FooInlined {
     #[ts(inline)]
     map: HashMap<usize, Bar>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_168/")]
+#[ts(export, export_to = "issue_168/")]
 struct Bar {
     #[ts(inline)]
     map: HashMap<usize, Baz>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_168/")]
+#[ts(export, export_to = "issue_168/")]
 struct Baz {
     #[ts(inline)]
     map: HashMap<usize, String>,

--- a/ts-rs/tests/issue-232.rs
+++ b/ts-rs/tests/issue-232.rs
@@ -3,14 +3,14 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_232/")]
+#[ts(export, export_to = "issue_232/")]
 struct State {
     a: Result<EnumWithName, String>,
     b: Result<EnumWithName, String>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_232/")]
+#[ts(export, export_to = "issue_232/")]
 struct StateInlined {
     #[ts(inline)]
     a: Result<EnumWithName, String>,
@@ -19,7 +19,7 @@ struct StateInlined {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_232/")]
+#[ts(export, export_to = "issue_232/")]
 struct StateInlinedVec {
     #[ts(inline)]
     a: Vec<Result<EnumWithName, String>>,
@@ -28,14 +28,14 @@ struct StateInlinedVec {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_232/")]
+#[ts(export, export_to = "issue_232/")]
 struct EnumWithName {
     name: String,
     inner: Enum,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_232/")]
+#[ts(export, export_to = "issue_232/")]
 enum Enum {
     A,
     B,

--- a/ts-rs/tests/issue-70.rs
+++ b/ts-rs/tests/issue-70.rs
@@ -7,14 +7,14 @@ use ts_rs::TS;
 type TypeAlias = HashMap<String, String>;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_70/")]
+#[ts(export, export_to = "issue_70/")]
 enum Enum {
     A(TypeAlias),
     B(HashMap<String, String>),
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_70/")]
+#[ts(export, export_to = "issue_70/")]
 struct Struct {
     a: TypeAlias,
     b: HashMap<String, String>,
@@ -33,7 +33,7 @@ fn issue_70() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_70/")]
+#[ts(export, export_to = "issue_70/")]
 struct GenericType<T, U> {
     foo: T,
     bar: U,
@@ -42,14 +42,14 @@ struct GenericType<T, U> {
 type GenericAlias<A = String, B = String> = GenericType<(A, String), Vec<(B, i32)>>;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_70/")]
+#[ts(export, export_to = "issue_70/")]
 struct Container {
     a: GenericAlias<Vec<i32>, Vec<String>>,
     b: GenericAlias,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/issue_70/")]
+#[ts(export, export_to = "issue_70/")]
 struct GenericContainer<A, B = i32> {
     a: GenericAlias,
     b: GenericAlias<A, B>,

--- a/ts-rs/tests/issue-80.rs
+++ b/ts-rs/tests/issue-80.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use ts_rs::TS;
 
 #[derive(TS, Serialize)]
-#[ts(export, export_to = "tests-out/issue_80/")]
+#[ts(export, export_to = "issue_80/")]
 pub enum SomeTypeList {
     Value1 {
         #[serde(skip)]

--- a/ts-rs/tests/lifetimes.rs
+++ b/ts-rs/tests/lifetimes.rs
@@ -3,19 +3,19 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/lifetimes/")]
+#[ts(export, export_to = "lifetimes/")]
 struct S<'a> {
     s: &'a str,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/lifetimes/")]
+#[ts(export, export_to = "lifetimes/")]
 struct B<'a, T: 'a> {
     a: &'a T,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/lifetimes/")]
+#[ts(export, export_to = "lifetimes/")]
 struct A<'a> {
     a: &'a &'a &'a Vec<u32>,                        //Multiple References
     b: &'a Vec<B<'a, u32>>,                         //Nesting

--- a/ts-rs/tests/list.rs
+++ b/ts-rs/tests/list.rs
@@ -2,7 +2,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/list/")]
+#[ts(export, export_to = "list/")]
 struct List {
     data: Option<Vec<u32>>,
 }

--- a/ts-rs/tests/nested.rs
+++ b/ts-rs/tests/nested.rs
@@ -5,14 +5,14 @@ use std::{cell::Cell, rc::Rc, sync::Arc};
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/nested/")]
+#[ts(export, export_to = "nested/")]
 struct A {
     x1: Arc<i32>,
     y1: Cell<i32>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/nested/")]
+#[ts(export, export_to = "nested/")]
 struct B {
     a1: Box<A>,
     #[ts(inline)]
@@ -20,7 +20,7 @@ struct B {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/nested/")]
+#[ts(export, export_to = "nested/")]
 struct C {
     b1: Rc<B>,
     #[ts(inline)]

--- a/ts-rs/tests/optional_field.rs
+++ b/ts-rs/tests/optional_field.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use ts_rs::TS;
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 struct OptionalInStruct {
     #[ts(optional)]
     a: Option<i32>,
@@ -22,7 +22,7 @@ fn in_struct() {
 }
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 enum OptionalInEnum {
     A {
         #[ts(optional)]
@@ -42,7 +42,7 @@ fn in_enum() {
 }
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 struct OptionalFlatten {
     #[ts(optional)]
     a: Option<i32>,
@@ -52,7 +52,7 @@ struct OptionalFlatten {
 }
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 struct Flatten {
     #[ts(flatten)]
     x: OptionalFlatten,
@@ -64,7 +64,7 @@ fn flatten() {
 }
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 struct OptionalInline {
     #[ts(optional)]
     a: Option<i32>,
@@ -74,7 +74,7 @@ struct OptionalInline {
 }
 
 #[derive(Serialize, TS)]
-#[ts(export, export_to = "tests-out/optional_field/")]
+#[ts(export, export_to = "optional_field/")]
 struct Inline {
     #[ts(inline)]
     x: OptionalInline,

--- a/ts-rs/tests/path_bug.rs
+++ b/ts-rs/tests/path_bug.rs
@@ -2,13 +2,13 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "../ts-rs/tests-out/path_bug/")]
+#[ts(export, export_to = "../ts-rs/path_bug/")]
 struct Foo {
     bar: Bar,
 }
 
 #[derive(TS)]
-#[ts(export_to = "tests-out/path_bug/aaa/")]
+#[ts(export_to = "path_bug/aaa/")]
 struct Bar {
     i: i32,
 }

--- a/ts-rs/tests/ranges.rs
+++ b/ts-rs/tests/ranges.rs
@@ -8,11 +8,11 @@ use std::{
 use ts_rs::{Dependency, TS};
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/ranges/")]
+#[ts(export, export_to = "ranges/")]
 struct Inner(i32);
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/ranges/")]
+#[ts(export, export_to = "ranges/")]
 struct RangeTest {
     a: Range<u32>,
     b: Range<&'static str>,

--- a/ts-rs/tests/raw_idents.rs
+++ b/ts-rs/tests/raw_idents.rs
@@ -3,7 +3,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/raw_idents/")]
+#[ts(export, export_to = "raw_idents/")]
 struct r#struct {
     r#type: i32,
     r#use: i32,

--- a/ts-rs/tests/references.rs
+++ b/ts-rs/tests/references.rs
@@ -3,7 +3,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/references/")]
+#[ts(export, export_to = "references/")]
 struct FullOfRefs<'a> {
     str_slice: &'a str,
     ref_slice: &'a [&'a str],

--- a/ts-rs/tests/self_referential.rs
+++ b/ts-rs/tests/self_referential.rs
@@ -7,13 +7,13 @@ use serde::Serialize;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/self_referential/")]
+#[ts(export, export_to = "self_referential/")]
 struct HasT {
     t: &'static T<'static>,
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/self_referential/")]
+#[ts(export, export_to = "self_referential/")]
 struct T<'a> {
     t_box: Box<T<'a>>,
     self_box: Box<Self>,
@@ -45,7 +45,7 @@ fn named() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/self_referential/", rename = "E")]
+#[ts(export, export_to = "self_referential/", rename = "E")]
 enum ExternallyTagged {
     A(Box<ExternallyTagged>),
     B(&'static ExternallyTagged),
@@ -129,7 +129,7 @@ fn enum_internally_tagged() {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/self_referential/", rename = "A")]
+#[ts(export, export_to = "self_referential/", rename = "A")]
 #[cfg_attr(feature = "serde-compat", serde(tag = "tag", content = "content"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "tag", content = "content"))]
 enum AdjacentlyTagged {

--- a/ts-rs/tests/semver.rs
+++ b/ts-rs/tests/semver.rs
@@ -5,7 +5,7 @@ use semver::Version;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/semver/")]
+#[ts(export, export_to = "semver/")]
 struct Semver {
     version: Version,
 }

--- a/ts-rs/tests/serde-skip-with-default.rs
+++ b/ts-rs/tests/serde-skip-with-default.rs
@@ -10,7 +10,7 @@ fn default_http_version() -> String {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, TS)]
-#[ts(export, export_to = "tests-out/serde_skip_with_default/")]
+#[ts(export, export_to = "serde_skip_with_default/")]
 pub struct Foobar {
     #[ts(skip)]
     #[serde(skip, default = "default_http_version")]

--- a/ts-rs/tests/simple.rs
+++ b/ts-rs/tests/simple.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/simple/")]
+#[ts(export, export_to = "simple/")]
 struct Simple {
     a: i32,
     b: String,

--- a/ts-rs/tests/skip.rs
+++ b/ts-rs/tests/skip.rs
@@ -8,7 +8,7 @@ use ts_rs::TS;
 struct Unsupported;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/skip/")]
+#[ts(export, export_to = "skip/")]
 struct Skip {
     a: i32,
     b: i32,
@@ -25,7 +25,7 @@ fn simple() {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/skip/")]
+#[ts(export, export_to = "skip/")]
 enum Externally {
     A(
         #[cfg_attr(feature = "serde-compat", serde(skip))]
@@ -64,7 +64,7 @@ fn externally_tagged() {
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "t"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "t"))]
-#[ts(export, export_to = "tests-out/skip/")]
+#[ts(export, export_to = "skip/")]
 enum Internally {
     A(
         #[cfg_attr(feature = "serde-compat", serde(skip))]
@@ -96,7 +96,7 @@ fn internally_tagged() {
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "t", content = "c"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "t", content = "c"))]
-#[ts(export, export_to = "tests-out/skip/")]
+#[ts(export, export_to = "skip/")]
 enum Adjacently {
     A(
         #[cfg_attr(feature = "serde-compat", serde(skip))]

--- a/ts-rs/tests/slices.rs
+++ b/ts-rs/tests/slices.rs
@@ -8,7 +8,7 @@ fn free() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/")]
+#[ts(export, export_to = "slices/")]
 struct Interface {
     #[allow(dead_code)]
     a: [i32],
@@ -20,7 +20,7 @@ fn interface() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/")]
+#[ts(export, export_to = "slices/")]
 struct InterfaceRef<'a> {
     #[allow(dead_code)]
     a: &'a [&'a str],
@@ -32,7 +32,7 @@ fn slice_ref() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/")]
+#[ts(export, export_to = "slices/")]
 struct Newtype(#[allow(dead_code)] [i32]);
 
 #[test]
@@ -49,7 +49,7 @@ fn boxed_free() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/")]
+#[ts(export, export_to = "slices/")]
 struct InterfaceBoxed {
     #[allow(dead_code)]
     a: Box<[i32]>,
@@ -61,7 +61,7 @@ fn boxed_interface() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/")]
+#[ts(export, export_to = "slices/")]
 struct NewtypeBoxed(#[allow(dead_code)] Box<[i32]>);
 
 #[test]
@@ -70,9 +70,9 @@ fn boxed_newtype() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/nested/")]
+#[ts(export, export_to = "slices/nested/")]
 struct InnerMost;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/slices/nested/")]
+#[ts(export, export_to = "slices/nested/")]
 struct Nested<'a>(&'a [InnerMost]);

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 #[derive(TS)]
 #[ts(
     export,
-    export_to = "tests-out/struct_rename/",
+    export_to = "struct_rename/",
     rename_all = "UPPERCASE"
 )]
 struct RenameAllUpper {
@@ -22,7 +22,7 @@ fn rename_all() {
 #[derive(TS)]
 #[ts(
     export,
-    export_to = "tests-out/struct_rename/",
+    export_to = "struct_rename/",
     rename_all = "camelCase"
 )]
 struct RenameAllCamel {
@@ -42,7 +42,7 @@ fn rename_all_camel_case() {
 #[derive(TS)]
 #[ts(
     export,
-    export_to = "tests-out/struct_rename/",
+    export_to = "struct_rename/",
     rename_all = "PascalCase"
 )]
 struct RenameAllPascal {
@@ -61,7 +61,7 @@ fn rename_all_pascal_case() {
 #[derive(serde::Serialize, TS)]
 #[ts(
     export,
-    export_to = "tests-out/struct_rename/",
+    export_to = "struct_rename/",
     rename_all = "camelCase"
 )]
 struct RenameSerdeSpecialChar {

--- a/ts-rs/tests/type_as.rs
+++ b/ts-rs/tests/type_as.rs
@@ -9,7 +9,7 @@ use ts_rs::TS;
 type Unsupported = UnsafeCell<MaybeUninit<NonNull<AtomicPtr<i32>>>>;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_as/")]
+#[ts(export, export_to = "type_as/")]
 struct ExternalTypeDef {
     a: i32,
     b: i32,
@@ -17,7 +17,7 @@ struct ExternalTypeDef {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_as/")]
+#[ts(export, export_to = "type_as/")]
 struct Override {
     a: i32,
     #[ts(as = "ExternalTypeDef")]
@@ -40,7 +40,7 @@ fn struct_properties() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_as/")]
+#[ts(export, export_to = "type_as/")]
 enum OverrideEnum {
     A(#[ts(as = "ExternalTypeDef")] Instant),
     B {
@@ -60,7 +60,7 @@ fn enum_variants() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_as/")]
+#[ts(export, export_to = "type_as/")]
 struct Outer {
     #[ts(as = "Option<ExternalTypeDef>")]
     #[ts(optional = nullable, inline)]

--- a/ts-rs/tests/type_override.rs
+++ b/ts-rs/tests/type_override.rs
@@ -10,7 +10,7 @@ struct Unsupported<T>(T);
 struct Unsupported2;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_override/")]
+#[ts(export, export_to = "type_override/")]
 struct Override {
     a: i32,
     #[ts(type = "0 | 1 | 2")]
@@ -32,11 +32,11 @@ fn simple() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_override/")]
+#[ts(export, export_to = "type_override/")]
 struct New1(#[ts(type = "string")] Unsupported2);
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/type_override/")]
+#[ts(export, export_to = "type_override/")]
 struct New2(#[ts(type = "string | null")] Unsupported<Unsupported2>);
 
 #[test]
@@ -52,7 +52,7 @@ struct S;
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "t"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "t"))]
-#[ts(export, export_to = "tests-out/type_override/")]
+#[ts(export, export_to = "type_override/")]
 enum Internal {
     Newtype(#[ts(type = "unknown")] S),
 }
@@ -61,7 +61,7 @@ enum Internal {
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "t", content = "c"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "t", content = "c"))]
-#[ts(export, export_to = "tests-out/type_override/")]
+#[ts(export, export_to = "type_override/")]
 enum Adjacent {
     Newtype(#[ts(type = "unknown")] S),
 }

--- a/ts-rs/tests/union.rs
+++ b/ts-rs/tests/union.rs
@@ -3,7 +3,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/union/")]
+#[ts(export, export_to = "union/")]
 enum SimpleEnum {
     #[ts(rename = "asdf")]
     A,

--- a/ts-rs/tests/union_named_serde_skip.rs
+++ b/ts-rs/tests/union_named_serde_skip.rs
@@ -8,7 +8,7 @@ use ts_rs::TS;
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(untagged))]
 #[cfg_attr(not(feature = "serde-compat"), ts(untagged))]
-#[ts(export, export_to = "tests-out/union_named_serde/")]
+#[ts(export, export_to = "union_named_serde/")]
 enum TestUntagged {
     A,   // serde_json -> `null`
     B(), // serde_json -> `[]`
@@ -21,7 +21,7 @@ enum TestUntagged {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
-#[ts(export, export_to = "tests-out/union_named_serde/")]
+#[ts(export, export_to = "union_named_serde/")]
 enum TestExternally {
     A,   // serde_json -> `"A"`
     B(), // serde_json -> `{"B":[]}`
@@ -36,7 +36,7 @@ enum TestExternally {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type", content = "content"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type", content = "content"))]
-#[ts(export, export_to = "tests-out/union_named_serde/")]
+#[ts(export, export_to = "union_named_serde/")]
 enum TestAdjacently {
     A,   // serde_json -> `{"type":"A"}`
     B(), // serde_json -> `{"type":"B","content":[]}`
@@ -51,7 +51,7 @@ enum TestAdjacently {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
-#[ts(export, export_to = "tests-out/union_named_serde/")]
+#[ts(export, export_to = "union_named_serde/")]
 enum TestInternally {
     A, // serde_json -> `{"type":"A"}`
     B, // serde_json -> `{"type":"B"}`

--- a/ts-rs/tests/union_rename.rs
+++ b/ts-rs/tests/union_rename.rs
@@ -3,7 +3,7 @@
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/union_rename/")]
+#[ts(export, export_to = "union_rename/")]
 #[ts(rename_all = "lowercase", rename = "SimpleEnum")]
 enum RenamedEnum {
     #[ts(rename = "ASDF")]

--- a/ts-rs/tests/union_serde.rs
+++ b/ts-rs/tests/union_serde.rs
@@ -8,7 +8,7 @@ use ts_rs::TS;
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "kind", content = "d"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "kind", content = "d"))]
-#[ts(export, export_to = "tests-out/union_serde/")]
+#[ts(export, export_to = "union_serde/")]
 enum SimpleEnum {
     A,
     B,
@@ -18,7 +18,7 @@ enum SimpleEnum {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "kind", content = "data"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "kind", content = "data"))]
-#[ts(export, export_to = "tests-out/union_serde/")]
+#[ts(export, export_to = "union_serde/")]
 enum ComplexEnum {
     A,
     B { foo: String, bar: f64 },
@@ -31,7 +31,7 @@ enum ComplexEnum {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(untagged))]
 #[cfg_attr(not(feature = "serde-compat"), ts(untagged))]
-#[ts(export, export_to = "tests-out/union_serde/")]
+#[ts(export, export_to = "union_serde/")]
 enum Untagged {
     Foo(String),
     Bar(i32),

--- a/ts-rs/tests/union_unnamed_serde_skip.rs
+++ b/ts-rs/tests/union_unnamed_serde_skip.rs
@@ -8,7 +8,7 @@ use ts_rs::TS;
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(untagged))]
 #[cfg_attr(not(feature = "serde-compat"), ts(untagged))]
-#[ts(export, export_to = "tests-out/union_unnamed_serde/")]
+#[ts(export, export_to = "union_unnamed_serde/")]
 enum TestUntagged {
     A,   // serde_json -> `null`
     B(), // serde_json -> `[]`
@@ -21,7 +21,7 @@ enum TestUntagged {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
-#[ts(export, export_to = "tests-out/union_unnamed_serde/")]
+#[ts(export, export_to = "union_unnamed_serde/")]
 enum TestExternally {
     A,   // serde_json -> `"A"`
     B(), // serde_json -> `{"B":[]}`
@@ -36,7 +36,7 @@ enum TestExternally {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type", content = "content"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type", content = "content"))]
-#[ts(export, export_to = "tests-out/union_unnamed_serde/")]
+#[ts(export, export_to = "union_unnamed_serde/")]
 enum TestAdjacently {
     A,   // serde_json -> `{"type":"A"}`
     B(), // serde_json -> `{"type":"B","content":[]}`
@@ -51,7 +51,7 @@ enum TestAdjacently {
 #[cfg_attr(feature = "serde-compat", derive(Deserialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
-#[ts(export, export_to = "tests-out/union_unnamed_serde/")]
+#[ts(export, export_to = "union_unnamed_serde/")]
 enum TestInternally {
     A, // serde_json -> `{"type":"A"}`
     B, // serde_json -> `{"type":"B"}`

--- a/ts-rs/tests/union_with_data.rs
+++ b/ts-rs/tests/union_with_data.rs
@@ -6,21 +6,21 @@ use ts_rs::{Dependency, TS};
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/union_with_data/")]
+#[ts(export, export_to = "union_with_data/")]
 struct Bar {
     field: i32,
 }
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/union_with_data/")]
+#[ts(export, export_to = "union_with_data/")]
 struct Foo {
     bar: Bar,
 }
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/union_with_data/")]
+#[ts(export, export_to = "union_with_data/")]
 enum SimpleEnum {
     A(String),
     B(i32),

--- a/ts-rs/tests/union_with_internal_tag.rs
+++ b/ts-rs/tests/union_with_internal_tag.rs
@@ -8,7 +8,7 @@ use ts_rs::TS;
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
-#[ts(export, export_to = "tests-out/union_with_internal_tag/")]
+#[ts(export, export_to = "union_with_internal_tag/")]
 enum EnumWithInternalTag {
     A { foo: String },
     B { bar: i32 },
@@ -16,14 +16,14 @@ enum EnumWithInternalTag {
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/union_with_internal_tag/")]
+#[ts(export, export_to = "union_with_internal_tag/")]
 struct InnerA {
     foo: String,
 }
 
 #[derive(TS)]
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
-#[ts(export, export_to = "tests-out/union_with_internal_tag/")]
+#[ts(export, export_to = "union_with_internal_tag/")]
 struct InnerB {
     bar: i32,
 }
@@ -32,7 +32,7 @@ struct InnerB {
 #[cfg_attr(feature = "serde-compat", derive(Serialize))]
 #[cfg_attr(feature = "serde-compat", serde(tag = "type"))]
 #[cfg_attr(not(feature = "serde-compat"), ts(tag = "type"))]
-#[ts(export, export_to = "tests-out/union_with_internal_tag/")]
+#[ts(export, export_to = "union_with_internal_tag/")]
 enum EnumWithInternalTag2 {
     A(InnerA),
     B(InnerB),

--- a/ts-rs/tests/unit.rs
+++ b/ts-rs/tests/unit.rs
@@ -2,24 +2,24 @@ use ts_rs::TS;
 
 // serde_json serializes this to `null`, so it's TS type is `null` as well.
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/unit/")]
+#[ts(export, export_to = "unit/")]
 struct Unit;
 
 // serde_json serializes this to `{}`.
 // The TS type best describing an empty object is `Record<string, never>`.
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/unit/")]
+#[ts(export, export_to = "unit/")]
 struct Unit2 {}
 
 // serde_json serializes this to `[]`.
 // The TS type best describing an empty array is `never[]`.
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/unit/")]
+#[ts(export, export_to = "unit/")]
 struct Unit3();
 
 // serde_json serializes this to `null`, so it's TS type is `null` as well.
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/unit/")]
+#[ts(export, export_to = "unit/")]
 struct Unit4(());
 
 #[test]

--- a/ts-rs/tests/unsized.rs
+++ b/ts-rs/tests/unsized.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, rc::Rc, sync::Arc};
 use ts_rs::TS;
 
 #[derive(TS)]
-#[ts(export, export_to = "tests-out/unsized/")]
+#[ts(export, export_to = "unsized/")]
 struct S<'a> {
     b: Box<str>,
     c: Cow<'a, str>,


### PR DESCRIPTION
Our tests got more nested than they previously were after changing how `TS_RS_EXPORT_DIR` behaves. This removes the extra nesting