### PR TITLE
Release v8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ We recommend doing this in your tests.
 ### get started
 ```toml
 [dependencies]
-ts-rs = "7.1"
+ts-rs = "8.0"
 ```
 
 ```rust

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ts-rs-macros"
-version = "7.1.1"
+version = "8.0.0"
 authors = ["Moritz Bischof <moritz.bischof1@gmail.com>"]
 edition = "2021"
 description = "derive macro for ts-rs"

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ts-rs"
-version = "7.1.1"
+version = "8.0.0"
 authors = ["Moritz Bischof <moritz.bischof1@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -39,10 +39,10 @@ chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
 heapless = { version = ">= 0.7, <= 0.8", optional = true }
-ts-rs-macros = { version = "7.1.1", path = "../macros" }
+ts-rs-macros = { version = "=8.0.0", path = "../macros" }
 dprint-plugin-typescript = { version = "0.89", optional = true }
 chrono = { version = "0.4", optional = true }
-bigdecimal = { version = ">= 0.0.13, <= 0.4", features = [
+bigdecimal = { version = ">= 0.0.13, <= 0.4.*", features = [
   "serde",
 ], optional = true }
 uuid = { version = "1", optional = true }

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -38,11 +38,11 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
-heapless = { version = ">= 0.7, <= 0.8", optional = true }
+heapless = { version = ">= 0.7, < 0.9", optional = true }
 ts-rs-macros = { version = "=8.0.0", path = "../macros" }
 dprint-plugin-typescript = { version = "0.89", optional = true }
 chrono = { version = "0.4", optional = true }
-bigdecimal = { version = ">= 0.0.13, <= 0.4.*", features = [
+bigdecimal = { version = ">= 0.0.13, < 0.5", features = [
   "serde",
 ], optional = true }
 uuid = { version = "1", optional = true }
@@ -52,4 +52,4 @@ url = { version = "2", optional = true }
 semver = { version = "1", optional = true }
 thiserror = "1"
 indexmap = { version = "2", optional = true }
-ordered-float = { version = ">= 3, <= 4", optional = true }
+ordered-float = { version = ">= 3, < 5", optional = true }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -40,7 +40,7 @@
 //! ## get started
 //! ```toml
 //! [dependencies]
-//! ts-rs = "7.1"
+//! ts-rs = "8.0"
 //! ```
 //!
 //! ```rust


### PR DESCRIPTION
## Goal

Let's get v8.0.0 released! 🚀 

## Changes

After the discussion in #251, I've now already bumped the version here.  
Aditionally, I've relaxed some dependencies:

- `heapless`
  We were supporting `0.7..=0.8`. I've relaxed this to `0.7..0.9`, since e.g `0.8.1` shouldn't introduce a breaking change
- `bigdecimal`
  We were supporting `0.0.13..=0.4`. I've relaxed this to `0.0.13..0.5`, for the same reason as above.
- `ordered-float`
  Same goes for `ordered-float`. Since that's beyond `0.x.x`, and we support `4.0`, we should also support `4.*.*`, so `<5`

I hope I didn't screw anything up here, semver always confuses me.

## Further ToDos
- [x] Get `#[ts(bound)]` merged
  Since it's a very straight-forward feature, i think we can get this in before release. It also makes a lot of sense to release it together with `#[ts(concrete)]` imho.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CHANGELOG.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
