### PR TITLE
Support serde with

### DIFF
--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -121,6 +121,9 @@ impl_parse! {
                 parse_assign_str(input)?;
             }
         },
-        "with" => out.0.using_serde_with = true,
+        "with" => {
+            parse_assign_str(input)?;
+            out.0.using_serde_with = true;
+        },
     }
 }

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -13,6 +13,9 @@ pub struct FieldAttr {
     pub optional: Optional,
     pub flatten: bool,
     pub docs: String,
+
+    #[cfg(feature = "serde-compat")]
+    pub using_serde_with: bool,
 }
 
 /// Indicates whether the field is marked with `#[ts(optional)]`.
@@ -52,6 +55,9 @@ impl FieldAttr {
             optional: Optional { optional, nullable },
             flatten,
             docs,
+
+            #[cfg(feature = "serde-compat")]
+            using_serde_with,
         }: FieldAttr,
     ) {
         self.rename = self.rename.take().or(rename);
@@ -65,6 +71,11 @@ impl FieldAttr {
         };
         self.flatten |= flatten;
         self.docs.push_str(&docs);
+
+        #[cfg(feature = "serde-compat")]
+        {
+            self.using_serde_with = self.using_serde_with || using_serde_with;
+        }
     }
 }
 
@@ -110,5 +121,6 @@ impl_parse! {
                 parse_assign_str(input)?;
             }
         },
+        "with" => out.0.using_serde_with = true,
     }
 }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use syn::{parse_quote, Attribute, Ident, Path, Result, Type, WherePredicate};
 
 use super::{parse_assign_from_str, parse_bound, parse_concrete};
-use crate::attr::EnumAttr;
 use crate::{
-    attr::{parse_assign_str, Inflection, VariantAttr},
+    attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
     utils::{parse_attrs, parse_docs},
 };
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -90,10 +90,20 @@ fn format_field(
         optional,
         flatten,
         docs,
+        #[cfg(feature = "serde-compat")]
+        using_serde_with,
     } = FieldAttr::from_attrs(&field.attrs)?;
 
     if skip {
         return Ok(());
+    }
+
+    #[cfg(feature = "serde-compat")]
+    if using_serde_with && !(type_as.is_some() || type_override.is_some()) {
+        syn_err_spanned!(
+            field;
+            r#"using `#[serde(with = "...")]` requires the use of `#[ts(as = "...")]` or `#[ts(type = "...")]`"#
+        )
     }
 
     if type_as.is_some() && type_override.is_some() {

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -24,9 +24,20 @@ pub(crate) fn newtype(attr: &StructAttr, name: &str, fields: &FieldsUnnamed) -> 
         optional,
         flatten,
         docs: _,
+
+        #[cfg(feature = "serde-compat")]
+        using_serde_with,
     } = FieldAttr::from_attrs(&inner.attrs)?;
 
     let crate_rename = attr.crate_rename();
+
+    #[cfg(feature = "serde-compat")]
+    if using_serde_with && !(type_as.is_some() || type_override.is_some()) {
+        syn_err_spanned!(
+            fields;
+            r#"using `#[serde(with = "...")]` requires the use of `#[ts(as = "...")]` or `#[ts(type = "...")]`"#
+        )
+    }
 
     match (&rename_inner, skip, optional.optional, flatten) {
         (Some(_), ..) => syn_err_spanned!(fields; "`rename` is not applicable to newtype fields"),

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -62,6 +62,9 @@ fn format_field(
         optional,
         flatten,
         docs: _,
+
+        #[cfg(feature = "serde-compat")]
+        using_serde_with,
     } = FieldAttr::from_attrs(&field.attrs)?;
 
     if skip {
@@ -69,6 +72,14 @@ fn format_field(
     }
 
     let ty = type_as.as_ref().unwrap_or(&field.ty).clone();
+
+    #[cfg(feature = "serde-compat")]
+    if using_serde_with && !(type_as.is_some() || type_override.is_some()) {
+        syn_err_spanned!(
+            field;
+            r#"using `#[serde(with = "...")]` requires the use of `#[ts(as = "...")]` or `#[ts(type = "...")]`"#
+        )
+    }
 
     if type_as.is_some() && type_override.is_some() {
         syn_err_spanned!(field; "`type` is not compatible with `as`")

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -138,11 +138,11 @@ pub use ts_rs_macros::TS;
 pub use crate::export::ExportError;
 use crate::typelist::TypeList;
 
-#[cfg(feature = "serde-json-impl")]
-mod serde_json;
 #[cfg(feature = "chrono-impl")]
 mod chrono;
 mod export;
+#[cfg(feature = "serde-json-impl")]
+mod serde_json;
 pub mod typelist;
 
 /// A type which can be represented in TypeScript.  

--- a/ts-rs/tests/serde_json.rs
+++ b/ts-rs/tests/serde_json.rs
@@ -61,5 +61,5 @@ fn inlined_value() {
 #[derive(TS)]
 #[ts(export, export_to = "serde_json_impl/")]
 struct Simple {
-    json: serde_json::Value
+    json: serde_json::Value,
 }


### PR DESCRIPTION
## Goal

Ensure the `#[serde(with = "...")]` attribute is properly handled in a way that prevents users from accidentally generating wrong TS type definitions by forgetting to add `#[ts(as = "...")]`/`#[ts(type = "...")]`,

### Why?

The `#[serde(with = "...")]` attribute changes how the type is serialized, therefore, it changes what type will be received by TypeScript, so the type generated by default will most likely be incorrect. The user must use `#[ts(as = "...")]` or `#[ts(type = "...")]` to ensure their type definition matches the type generated by serde

### Why not make `#[serde(with = "...")]` an alias for `#[ts(as = "...")]`

`#[ts(as = "...")]` only accepts types, where as `#[serde(with = "...")]` accepts either a type or a path to a module containing both a `serialize` and a `deserialize` function, so the attributes are not compatible and thus cannot just alias each other

Closes #275

## Changes

When the `serde-compat` feature is enabled, using  `#[serde(with = "...")]` will result in a compiler error if either `#[ts(as = "...")]` or `#[ts(type = "...")]` is not added

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

## Todo

- [ ] Find a way to test the compiler error case (`compiletest_rs`?)
