### PR TITLE
Fix `#[ts(rename_all_fields = "...")]` on enums containing tuple or unit variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # master
+
 ### Breaking
+
 ### Features
+
 ### Fixes
 
+Fix `#[ts(rename_all_fields = "...")]` on enums containing tuple or unit variants ([#287](https://github.com/Aleph-Alpha/ts-rs/pull/287))
 
 # 8.1.0
 

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -21,14 +21,8 @@ pub struct SerdeVariantAttr(VariantAttr);
 
 impl VariantAttr {
     pub fn new(attrs: &[Attribute], enum_attr: &EnumAttr) -> Result<Self> {
-        let mut result = Self::default();
-        parse_attrs(attrs)?.for_each(|a| result.merge(a));
+        let mut result = Self::from_attrs(attrs)?;
         result.rename_all = result.rename_all.or(enum_attr.rename_all_fields);
-        #[cfg(feature = "serde-compat")]
-        if !result.skip {
-            crate::utils::parse_serde_attrs::<SerdeVariantAttr>(attrs)
-                .for_each(|a| result.merge(a.0));
-        }
         Ok(result)
     }
 

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -32,6 +32,17 @@ impl VariantAttr {
         Ok(result)
     }
 
+    pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
+        let mut result = Self::default();
+        parse_attrs(attrs)?.for_each(|a| result.merge(a));
+        #[cfg(feature = "serde-compat")]
+        if !result.skip {
+            crate::utils::parse_serde_attrs::<SerdeVariantAttr>(attrs)
+                .for_each(|a| result.merge(a.0));
+        }
+        Ok(result)
+    }
+
     fn merge(
         &mut self,
         VariantAttr {

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -71,7 +71,10 @@ fn format_variant(
     variant: &Variant,
 ) -> syn::Result<()> {
     let crate_rename = enum_attr.crate_rename();
-    let variant_attr = VariantAttr::new(&variant.attrs, enum_attr)?;
+    let variant_attr = match variant.fields {
+        Fields::Unit | Fields::Unnamed(_) => VariantAttr::from_attrs(&variant.attrs)?,
+        Fields::Named(_) => VariantAttr::new(&variant.attrs, enum_attr)?,
+    };
 
     if variant_attr.skip {
         return Ok(());

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -71,6 +71,10 @@ fn format_variant(
     variant: &Variant,
 ) -> syn::Result<()> {
     let crate_rename = enum_attr.crate_rename();
+
+    // If `variant.fields` is not a `Fields::Named(_)` the `rename_all_fields`
+    // attribute must be ignored to prevent a `rename_all` from getting to
+    // the newtype, tuple or unit formatting, which would cause an error
     let variant_attr = match variant.fields {
         Fields::Unit | Fields::Unnamed(_) => VariantAttr::from_attrs(&variant.attrs)?,
         Fields::Named(_) => VariantAttr::new(&variant.attrs, enum_attr)?,

--- a/ts-rs/tests/enum_struct_rename_all.rs
+++ b/ts-rs/tests/enum_struct_rename_all.rs
@@ -44,12 +44,16 @@ pub enum TaskStatus2 {
         stdout: String,
         stderr: String,
     },
+
+    A(i32),
+    B(i32, i32),
+    C,
 }
 
 #[test]
 pub fn enum_struct_rename_all_fields() {
     assert_eq!(
         TaskStatus2::inline(),
-        r#"{ "Running": { "started-time": string, } } | { "Terminated": { status: number, stdout: string, stderr: string, } }"#
+        r#"{ "Running": { "started-time": string, } } | { "Terminated": { status: number, stdout: string, stderr: string, } } | { "A": number } | { "B": [number, number] } | "C""#
     )
 }


### PR DESCRIPTION
## Goal

Using `#[ts(rename_all_fields = "...")]` on an enum containing tuple or unit variants would cause the error "`rename_all` is not applicable to newtype/tuple/unit structs" 

## Changes

Only add `rename_all` from `rename_all_fields` if `variant.fields` is `Fields::Named(_)`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
