### PR TITLE
Rework attribute parsing

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -104,7 +104,7 @@ impl Attr for EnumAttr {
                     "`as` is not compatible with `type`"
                 );
             }
-          
+
             if self.rename_all.is_some() {
                 syn_err_spanned!(
                     item;

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -51,7 +51,7 @@ impl EnumAttr {
     }
 
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut result = parse_attrs(attrs)?.fold(Self::default(), |acc, cur| acc.merge(cur));
+        let mut result = parse_attrs::<Self>(attrs)?;
 
         let docs = parse_docs(attrs)?;
         result.docs = docs;

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -141,6 +141,43 @@ impl Attr for EnumAttr {
             }
         }
 
+        if self.type_as.is_some() {
+            if self.rename_all.is_some() {
+                syn_err_spanned!(
+                    item;
+                    "`rename_all` is not compatible with `as`"
+                );
+            }
+
+            if self.rename_all_fields.is_some() {
+                syn_err_spanned!(
+                    item;
+                    "`rename_all_fields` is not compatible with `as`"
+                );
+            }
+
+            if self.tag.is_some() {
+                syn_err_spanned!(
+                    item;
+                    "`tag` is not compatible with `as`"
+                );
+            }
+
+            if self.content.is_some() {
+                syn_err_spanned!(
+                    item;
+                    "`content` is not compatible with `as`"
+                );
+            }
+
+            if self.untagged {
+                syn_err_spanned!(
+                    item;
+                    "`untagged` is not compatible with `as`"
+                );
+            }
+        }
+
         match (self.untagged, &self.tag, &self.content) {
             (true, Some(_), None) => syn_err_spanned!(
                 item;

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -50,14 +50,14 @@ impl EnumAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
         let mut result = parse_attrs::<Self>(attrs)?;
 
-        let docs = parse_docs(attrs)?;
-        result.docs = docs;
-
         #[cfg(feature = "serde-compat")]
         {
             let serde_attr = crate::utils::parse_serde_attrs::<EnumAttr>(attrs);
-            result.merge_with_serde(serde_attr);
+            result = result.merge(serde_attr.0);
         }
+
+        let docs = parse_docs(attrs)?;
+        result.docs = docs;
 
         Ok(result)
     }
@@ -93,17 +93,6 @@ impl Attr for EnumAttr {
                 (None, None) => None,
             },
         }
-    }
-
-    #[cfg(feature = "serde-compat")]
-    fn merge_with_serde(&mut self, serde: Serde<Self>) {
-        self.rename = self.rename.take().or(serde.0.rename);
-        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
-        self.rename_all_fields = self.rename_all_fields.take().or(serde.0.rename_all_fields);
-        self.tag = self.tag.take().or(serde.0.tag);
-        self.content = self.content.take().or(serde.0.content);
-        self.untagged = self.untagged || serde.0.untagged;
-        self.bound = self.bound.take().or(serde.0.bound);
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -55,7 +55,8 @@ impl EnumAttr {
 
         #[cfg(feature = "serde-compat")]
         {
-            result = crate::utils::parse_serde_attrs::<EnumAttr>(attrs, result);
+            let serde_attr = crate::utils::parse_serde_attrs::<EnumAttr>(attrs);
+            result.merge_with_serde(serde_attr);
         }
 
         Ok(result)
@@ -92,6 +93,17 @@ impl Attr for EnumAttr {
                 (None, None) => None,
             },
         }
+    }
+
+    #[cfg(feature = "serde-compat")]
+    fn merge_with_serde(&mut self, serde: Serde<Self>) {
+        self.rename = self.rename.take().or(serde.0.rename);
+        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
+        self.rename_all_fields = self.rename_all_fields.take().or(serde.0.rename_all_fields);
+        self.tag = self.tag.take().or(serde.0.tag);
+        self.content = self.content.take().or(serde.0.content);
+        self.untagged = self.untagged || serde.0.untagged;
+        self.bound = self.bound.take().or(serde.0.bound);
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -30,7 +30,7 @@ pub struct SerdeFieldAttr(FieldAttr);
 
 impl FieldAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut result = parse_attrs(attrs)?.fold(Self::default(), |acc, cur| acc.merge(cur));
+        let mut result = parse_attrs::<Self>(attrs)?;
 
         result.docs = parse_docs(attrs)?;
 

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -32,7 +32,8 @@ impl FieldAttr {
 
         #[cfg(feature = "serde-compat")]
         if !result.skip {
-            result = crate::utils::parse_serde_attrs::<FieldAttr>(attrs, result);
+            let serde_attr = crate::utils::parse_serde_attrs::<FieldAttr>(attrs);
+            result.merge_with_serde(serde_attr)
         }
 
         Ok(result)
@@ -64,6 +65,13 @@ impl Attr for FieldAttr {
                 self.docs + &other.docs
             },
         }
+    }
+
+    #[cfg(feature = "serde-compat")]
+    fn merge_with_serde(&mut self, serde: Serde<Self>) {
+        self.rename = self.rename.take().or(serde.0.rename);
+        self.skip = self.skip || serde.0.skip;
+        self.flatten = self.flatten || serde.0.flatten;
     }
 
     fn assert_validity(&self, field: &Self::Item) -> Result<()> {

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -28,13 +28,13 @@ impl FieldAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
         let mut result = parse_attrs::<Self>(attrs)?;
 
-        result.docs = parse_docs(attrs)?;
-
         #[cfg(feature = "serde-compat")]
         if !result.skip {
             let serde_attr = crate::utils::parse_serde_attrs::<FieldAttr>(attrs);
-            result.merge_with_serde(serde_attr)
+            result = result.merge(serde_attr.0);
         }
+
+        result.docs = parse_docs(attrs)?;
 
         Ok(result)
     }
@@ -65,13 +65,6 @@ impl Attr for FieldAttr {
                 self.docs + &other.docs
             },
         }
-    }
-
-    #[cfg(feature = "serde-compat")]
-    fn merge_with_serde(&mut self, serde: Serde<Self>) {
-        self.rename = self.rename.take().or(serde.0.rename);
-        self.skip = self.skip || serde.0.skip;
-        self.flatten = self.flatten || serde.0.flatten;
     }
 
     fn assert_validity(&self, field: &Self::Item) -> Result<()> {

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -48,7 +48,7 @@ impl<T> Attr for Serde<T>
 where
     T: Attr,
 {
-    type Item = syn::Error;
+    type Item = std::convert::Infallible;
 
     fn merge(self, other: Self) -> Self {
         Self(self.0.merge(other.0))

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -37,6 +37,28 @@ pub(super) trait ContainerAttr: Attr {
     fn crate_rename(&self) -> Path;
 }
 
+#[cfg(feature = "serde-compat")]
+#[derive(Default)]
+pub(super) struct Serde<T>(pub T)
+where
+    T: Attr;
+
+#[cfg(feature = "serde-compat")]
+impl<T> Attr for Serde<T>
+where
+    T: Attr,
+{
+    type Item = syn::Error;
+
+    fn merge(self, other: Self) -> Self {
+        Self(self.0.merge(other.0))
+    }
+
+    fn assert_validity(&self, _: &Self::Item) -> Result<()> {
+        unimplemented!("This method should not be called on Serde<T>")
+    }
+}
+
 impl Inflection {
     pub fn apply(self, string: &str) -> String {
         use inflector::Inflector;

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -30,6 +30,8 @@ pub(super) trait Attr: Default {
     type Item;
 
     fn merge(self, other: Self) -> Self;
+    #[cfg(feature = "serde-compat")]
+    fn merge_with_serde(&mut self, serde: Serde<Self>);
     fn assert_validity(&self, item: &Self::Item) -> Result<()>;
 }
 
@@ -44,18 +46,12 @@ where
     T: Attr;
 
 #[cfg(feature = "serde-compat")]
-impl<T> Attr for Serde<T>
+impl<T> Serde<T>
 where
     T: Attr,
 {
-    type Item = std::convert::Infallible;
-
-    fn merge(self, other: Self) -> Self {
+    pub fn merge(self, other: Self) -> Self {
         Self(self.0.merge(other.0))
-    }
-
-    fn assert_validity(&self, _: &Self::Item) -> Result<()> {
-        unimplemented!("This method should not be called on Serde<T>")
     }
 }
 

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -30,8 +30,6 @@ pub(super) trait Attr: Default {
     type Item;
 
     fn merge(self, other: Self) -> Self;
-    #[cfg(feature = "serde-compat")]
-    fn merge_with_serde(&mut self, serde: Serde<Self>);
     fn assert_validity(&self, item: &Self::Item) -> Result<()>;
 }
 

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -6,7 +6,7 @@ pub use r#struct::*;
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    Error, Lit, Result, Token, WherePredicate,
+    Error, Lit, Path, Result, Token, WherePredicate,
 };
 pub use variant::*;
 
@@ -24,6 +24,17 @@ pub enum Inflection {
     Pascal,
     ScreamingSnake,
     Kebab,
+}
+
+pub(super) trait Attr {
+    type Item;
+
+    fn merge(self, other: Self) -> Self;
+    fn assert_validity(&self, item: &Self::Item) -> Result<()>;
+}
+
+pub(super) trait ContainerAttr: Attr {
+    fn crate_rename(&self) -> Path;
 }
 
 impl Inflection {

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -26,7 +26,7 @@ pub enum Inflection {
     Kebab,
 }
 
-pub(super) trait Attr {
+pub(super) trait Attr: Default {
     type Item;
 
     fn merge(self, other: Self) -> Self;

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -96,6 +96,16 @@ impl Attr for StructAttr {
             }
         }
 
+        if self.type_as.is_some() {
+            if self.tag.is_some() {
+                syn_err!("`tag` is not compatible with `as`");
+            }
+
+            if self.rename_all.is_some() {
+                syn_err!("`rename_all` is not compatible with `as`");
+            }
+        }
+
         if !matches!(item, Fields::Named(_)) {
             if self.tag.is_some() {
                 syn_err!("`tag` cannot be used with unit or tuple structs");

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -32,7 +32,8 @@ impl StructAttr {
 
         #[cfg(feature = "serde-compat")]
         {
-            result = crate::utils::parse_serde_attrs::<StructAttr>(attrs, result);
+            let serde_attr = crate::utils::parse_serde_attrs::<StructAttr>(attrs);
+            result.merge_with_serde(serde_attr)
         }
         Ok(result)
     }
@@ -76,6 +77,14 @@ impl Attr for StructAttr {
                 (None, None) => None,
             },
         }
+    }
+
+    #[cfg(feature = "serde-compat")]
+    fn merge_with_serde(&mut self, serde: Serde<Self>) {
+        self.rename = self.rename.take().or(serde.0.rename);
+        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
+        self.tag = self.tag.take().or(serde.0.tag);
+        self.bound = self.bound.take().or(serde.0.bound);
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -27,14 +27,15 @@ impl StructAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
         let mut result = parse_attrs::<Self>(attrs)?;
 
-        let docs = parse_docs(attrs)?;
-        result.docs = docs;
-
         #[cfg(feature = "serde-compat")]
         {
             let serde_attr = crate::utils::parse_serde_attrs::<StructAttr>(attrs);
-            result.merge_with_serde(serde_attr)
+            result = result.merge(serde_attr.0);
         }
+
+        let docs = parse_docs(attrs)?;
+        result.docs = docs;
+        
         Ok(result)
     }
 
@@ -77,14 +78,6 @@ impl Attr for StructAttr {
                 (None, None) => None,
             },
         }
-    }
-
-    #[cfg(feature = "serde-compat")]
-    fn merge_with_serde(&mut self, serde: Serde<Self>) {
-        self.rename = self.rename.take().or(serde.0.rename);
-        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
-        self.tag = self.tag.take().or(serde.0.tag);
-        self.bound = self.bound.take().or(serde.0.bound);
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -28,7 +28,7 @@ pub struct SerdeStructAttr(StructAttr);
 
 impl StructAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut result = parse_attrs(attrs)?.fold(Self::default(), |acc, cur| acc.merge(cur));
+        let mut result = parse_attrs::<Self>(attrs)?;
 
         let docs = parse_docs(attrs)?;
         result.docs = docs;

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -21,7 +21,7 @@ pub struct SerdeVariantAttr(VariantAttr);
 
 impl VariantAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut result = parse_attrs(attrs)?.fold(Self::default(), |acc, cur| acc.merge(cur));
+        let mut result = parse_attrs::<Self>(attrs)?;
         #[cfg(feature = "serde-compat")]
         if !result.skip {
             result = crate::utils::parse_serde_attrs::<SerdeVariantAttr>(attrs)

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -1,6 +1,6 @@
 use syn::{Attribute, Fields, Ident, Result, Variant};
 
-use super::Attr;
+use super::{Attr, Serde};
 use crate::{
     attr::{parse_assign_inflection, parse_assign_str, Inflection},
     utils::parse_attrs,
@@ -15,17 +15,12 @@ pub struct VariantAttr {
     pub untagged: bool,
 }
 
-#[cfg(feature = "serde-compat")]
-#[derive(Default)]
-pub struct SerdeVariantAttr(VariantAttr);
-
 impl VariantAttr {
     pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
         let mut result = parse_attrs::<Self>(attrs)?;
         #[cfg(feature = "serde-compat")]
         if !result.skip {
-            result = crate::utils::parse_serde_attrs::<SerdeVariantAttr>(attrs)
-                .fold(result, |acc, cur| acc.merge(cur.0));
+            result = crate::utils::parse_serde_attrs::<VariantAttr>(attrs, result);
         }
         Ok(result)
     }
@@ -68,7 +63,7 @@ impl_parse! {
 
 #[cfg(feature = "serde-compat")]
 impl_parse! {
-    SerdeVariantAttr(input, out) {
+    Serde<VariantAttr>(input, out) {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "skip" => out.0.skip = true,

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -21,7 +21,7 @@ impl VariantAttr {
         #[cfg(feature = "serde-compat")]
         if !result.skip {
             let serde_attr = crate::utils::parse_serde_attrs::<VariantAttr>(attrs);
-            result.merge_with_serde(serde_attr);
+            result = result.merge(serde_attr.0);
         }
         Ok(result)
     }
@@ -38,14 +38,6 @@ impl Attr for VariantAttr {
             skip: self.skip || other.skip,
             untagged: self.untagged || other.untagged,
         }
-    }
-
-    #[cfg(feature = "serde-compat")]
-    fn merge_with_serde(&mut self, serde: Serde<Self>) {
-        self.rename = self.rename.take().or(serde.0.rename);
-        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
-        self.skip = self.skip || serde.0.skip;
-        self.untagged = self.untagged || serde.0.untagged;
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -20,7 +20,7 @@ impl VariantAttr {
         let mut result = parse_attrs::<Self>(attrs)?;
         #[cfg(feature = "serde-compat")]
         if !result.skip {
-            let serde_attr = crate::utils::parse_serde_attrs::<VariantAttr>(attrs, result);
+            let serde_attr = crate::utils::parse_serde_attrs::<VariantAttr>(attrs);
             result.merge_with_serde(serde_attr);
         }
         Ok(result)

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -20,7 +20,8 @@ impl VariantAttr {
         let mut result = parse_attrs::<Self>(attrs)?;
         #[cfg(feature = "serde-compat")]
         if !result.skip {
-            result = crate::utils::parse_serde_attrs::<VariantAttr>(attrs, result);
+            let serde_attr = crate::utils::parse_serde_attrs::<VariantAttr>(attrs, result);
+            result.merge_with_serde(serde_attr);
         }
         Ok(result)
     }
@@ -37,6 +38,14 @@ impl Attr for VariantAttr {
             skip: self.skip || other.skip,
             untagged: self.untagged || other.untagged,
         }
+    }
+
+    #[cfg(feature = "serde-compat")]
+    fn merge_with_serde(&mut self, serde: Serde<Self>) {
+        self.rename = self.rename.take().or(serde.0.rename);
+        self.rename_all = self.rename_all.take().or(serde.0.rename_all);
+        self.skip = self.skip || serde.0.skip;
+        self.untagged = self.untagged || serde.0.untagged;
     }
 
     fn assert_validity(&self, item: &Self::Item) -> Result<()> {

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, quote};
 use syn::{Fields, ItemEnum, Variant};
 
 use crate::{
-    attr::{EnumAttr, FieldAttr, StructAttr, Tagged, VariantAttr},
+    attr::{Attr, EnumAttr, FieldAttr, StructAttr, Tagged, VariantAttr},
     deps::Dependencies,
     types::{self, type_override},
     DerivedTS,
@@ -11,6 +11,8 @@ use crate::{
 
 pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
     let enum_attr: EnumAttr = EnumAttr::from_attrs(&s.attrs)?;
+
+    enum_attr.assert_validity(s)?;
 
     let crate_rename = enum_attr.crate_rename();
 
@@ -80,10 +82,9 @@ fn format_variant(
     // If `variant.fields` is not a `Fields::Named(_)` the `rename_all_fields`
     // attribute must be ignored to prevent a `rename_all` from getting to
     // the newtype, tuple or unit formatting, which would cause an error
-    let variant_attr = match variant.fields {
-        Fields::Unit | Fields::Unnamed(_) => VariantAttr::from_attrs(&variant.attrs)?,
-        Fields::Named(_) => VariantAttr::new(&variant.attrs, enum_attr)?,
-    };
+    let variant_attr = VariantAttr::from_attrs(&variant.attrs)?;
+
+    variant_attr.assert_validity(variant)?;
 
     if variant_attr.skip {
         return Ok(());
@@ -96,7 +97,7 @@ fn format_variant(
         (None, Some(rn)) => rn.apply(&variant.ident.to_string()),
     };
 
-    let struct_attr = StructAttr::from_variant(enum_attr, &variant_attr);
+    let struct_attr = StructAttr::from_variant(enum_attr, &variant_attr, &variant.fields);
     let variant_type = types::type_def(
         &struct_attr,
         // since we are generating the variant as a struct, it doesn't have a name
@@ -111,8 +112,12 @@ fn format_variant(
         (false, Tagged::Externally) => match &variant.fields {
             Fields::Unit => quote!(format!("\"{}\"", #name)),
             Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
-                let FieldAttr { skip, .. } = FieldAttr::from_attrs(&unnamed.unnamed[0].attrs)?;
-                if skip {
+                let field = &unnamed.unnamed[0];
+                let field_attr = FieldAttr::from_attrs(&field.attrs)?;
+
+                field_attr.assert_validity(field)?;
+
+                if field_attr.skip {
                     quote!(format!("\"{}\"", #name))
                 } else {
                     quote!(format!("{{ \"{}\": {} }}", #name, #inline_type))
@@ -122,19 +127,24 @@ fn format_variant(
         },
         (false, Tagged::Adjacently { tag, content }) => match &variant.fields {
             Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+                let field = &unnamed.unnamed[0];
+                let field_attr = FieldAttr::from_attrs(&unnamed.unnamed[0].attrs)?;
+
+                field_attr.assert_validity(field)?;
+
                 let FieldAttr {
                     type_as,
                     type_override,
                     skip,
                     ..
-                } = FieldAttr::from_attrs(&unnamed.unnamed[0].attrs)?;
+                } = field_attr;
 
                 if skip {
                     quote!(format!("{{ \"{}\": \"{}\" }}", #tag, #name))
                 } else {
                     let ty = match (type_override, type_as) {
                         (Some(_), Some(_)) => {
-                            syn_err_spanned!(variant; "`type` is not compatible with `as`")
+                            unreachable!("This has been handled by assert_validity")
                         }
                         (Some(type_override), None) => quote! { #type_override },
                         (None, Some(type_as)) => {
@@ -173,19 +183,24 @@ fn format_variant(
             },
             None => match &variant.fields {
                 Fields::Unnamed(unnamed) if unnamed.unnamed.len() == 1 => {
+                    let field = &unnamed.unnamed[0];
+                    let field_attr = FieldAttr::from_attrs(&unnamed.unnamed[0].attrs)?;
+
+                    field_attr.assert_validity(field)?;
+
                     let FieldAttr {
                         type_as,
                         skip,
                         type_override,
                         ..
-                    } = FieldAttr::from_attrs(&unnamed.unnamed[0].attrs)?;
+                    } = field_attr;
 
                     if skip {
                         quote!(format!("{{ \"{}\": \"{}\" }}", #tag, #name))
                     } else {
                         let ty = match (type_override, type_as) {
                             (Some(_), Some(_)) => {
-                                syn_err_spanned!(variant; "`type` is not compatible with `as`")
+                                unreachable!("This has been handled by assert_validity")
                             }
                             (Some(type_override), None) => quote! { #type_override },
                             (None, Some(type_as)) => {

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -1,6 +1,10 @@
 use syn::{Fields, Ident, ItemStruct, Result};
 
-use crate::{attr::StructAttr, utils::to_ts_ident, DerivedTS};
+use crate::{
+    attr::{Attr, StructAttr},
+    utils::to_ts_ident,
+    DerivedTS,
+};
 
 mod r#enum;
 mod named;
@@ -18,6 +22,8 @@ pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
 }
 
 fn type_def(attr: &StructAttr, ident: &Ident, fields: &Fields) -> Result<DerivedTS> {
+    attr.assert_validity(fields)?;
+
     let name = attr.rename.clone().unwrap_or_else(|| to_ts_ident(ident));
     if let Some(attr_type_override) = &attr.type_override {
         return type_override::type_override_struct(attr, &name, attr_type_override);

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -5,7 +5,7 @@ use syn::{
 };
 
 use crate::{
-    attr::{FieldAttr, Inflection, Optional, StructAttr},
+    attr::{Attr, ContainerAttr, FieldAttr, Inflection, Optional, StructAttr},
     deps::Dependencies,
     utils::{raw_name_to_ts_field, to_ts_ident},
     DerivedTS,
@@ -88,6 +88,10 @@ fn format_field(
     field: &Field,
     rename_all: &Option<Inflection>,
 ) -> Result<()> {
+    let field_attr = FieldAttr::from_attrs(&field.attrs)?;
+
+    field_attr.assert_validity(field)?;
+
     let FieldAttr {
         type_as,
         type_override,
@@ -97,14 +101,10 @@ fn format_field(
         optional,
         flatten,
         docs,
-    } = FieldAttr::from_attrs(&field.attrs)?;
+    } = field_attr;
 
     if skip {
         return Ok(());
-    }
-
-    if type_as.is_some() && type_override.is_some() {
-        syn_err_spanned!(field; "`type` is not compatible with `as`")
     }
 
     let parsed_ty = type_as.as_ref().unwrap_or(&field.ty).clone();
@@ -126,18 +126,6 @@ fn format_field(
     };
 
     if flatten {
-        match (&type_as, &type_override, &rename, inline) {
-            (Some(_), _, _, _) => syn_err_spanned!(field; "`as` is not compatible with `flatten`"),
-            (_, Some(_), _, _) => {
-                syn_err_spanned!(field; "`type` is not compatible with `flatten`")
-            }
-            (_, _, Some(_), _) => {
-                syn_err_spanned!(field; "`rename` is not compatible with `flatten`")
-            }
-            (_, _, _, true) => syn_err_spanned!(field; "`inline` is not compatible with `flatten`"),
-            _ => {}
-        }
-
         flattened_fields.push(quote!(<#ty as #crate_rename::TS>::inline_flattened()));
         dependencies.append_from(ty);
         return Ok(());
@@ -152,6 +140,7 @@ fn format_field(
             quote!(<#ty as #crate_rename::TS>::name())
         }
     });
+
     let field_name = to_ts_ident(field.ident.as_ref().unwrap());
     let name = match (rename, rename_all) {
         (Some(rn), _) => rn,

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -2,56 +2,39 @@ use quote::quote;
 use syn::{FieldsUnnamed, Result};
 
 use crate::{
-    attr::{FieldAttr, StructAttr},
+    attr::{Attr, ContainerAttr, FieldAttr, StructAttr},
     deps::Dependencies,
     DerivedTS,
 };
 
 pub(crate) fn newtype(attr: &StructAttr, name: &str, fields: &FieldsUnnamed) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not applicable to newtype structs");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not applicable to newtype structs");
-    }
     let inner = fields.unnamed.first().unwrap();
+
+    let field_attr = FieldAttr::from_attrs(&inner.attrs)?;
+    field_attr.assert_validity(inner)?;
+
     let FieldAttr {
         type_as,
         type_override,
-        rename: rename_inner,
         inline,
         skip,
-        optional,
-        flatten,
-        docs: _,
-    } = FieldAttr::from_attrs(&inner.attrs)?;
+        ..
+    } = field_attr;
 
     let crate_rename = attr.crate_rename();
 
-    match (&rename_inner, skip, optional.optional, flatten) {
-        (Some(_), ..) => syn_err_spanned!(fields; "`rename` is not applicable to newtype fields"),
-        (_, true, ..) => return super::unit::null(attr, name),
-        (_, _, true, ..) => {
-            syn_err_spanned!(fields; "`optional` is not applicable to newtype fields")
-        }
-        (_, _, _, true) => {
-            syn_err_spanned!(fields; "`flatten` is not applicable to newtype fields")
-        }
-        _ => {}
-    };
-
-    if type_as.is_some() && type_override.is_some() {
-        syn_err_spanned!(fields; "`type` is not compatible with `as`")
+    if skip {
+        return super::unit::null(attr, name);
     }
 
     let inner_ty = type_as.as_ref().unwrap_or(&inner.ty).clone();
 
     let mut dependencies = Dependencies::new(crate_rename.clone());
 
-    match (type_override.is_none(), inline) {
-        (false, _) => (),
-        (true, true) => dependencies.append_from(&inner_ty),
-        (true, false) => dependencies.push(&inner_ty),
+    match (&type_override, inline) {
+        (Some(_), _) => (),
+        (None, true) => dependencies.append_from(&inner_ty),
+        (None, false) => dependencies.push(&inner_ty),
     };
 
     let inline_def = match type_override {

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -3,19 +3,12 @@ use quote::quote;
 use syn::{Field, FieldsUnnamed, Path, Result};
 
 use crate::{
-    attr::{FieldAttr, StructAttr},
+    attr::{Attr, ContainerAttr, FieldAttr, StructAttr},
     deps::Dependencies,
     DerivedTS,
 };
 
 pub(crate) fn tuple(attr: &StructAttr, name: &str, fields: &FieldsUnnamed) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not applicable to tuple structs");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not applicable to tuple structs");
-    }
-
     let crate_rename = attr.crate_rename();
     let mut formatted_fields = Vec::new();
     let mut dependencies = Dependencies::new(crate_rename.clone());
@@ -53,38 +46,25 @@ fn format_field(
     dependencies: &mut Dependencies,
     field: &Field,
 ) -> Result<()> {
+    let field_attr = FieldAttr::from_attrs(&field.attrs)?;
+    field_attr.assert_validity(field)?;
+
     let FieldAttr {
         type_as,
         type_override,
-        rename,
+        rename: _,
         inline,
         skip,
-        optional,
-        flatten,
+        optional: _,
+        flatten: _,
         docs: _,
-    } = FieldAttr::from_attrs(&field.attrs)?;
+    } = field_attr;
 
     if skip {
         return Ok(());
     }
 
     let ty = type_as.as_ref().unwrap_or(&field.ty).clone();
-
-    if type_as.is_some() && type_override.is_some() {
-        syn_err_spanned!(field; "`type` is not compatible with `as`")
-    }
-
-    if rename.is_some() {
-        syn_err_spanned!(field; "`rename` is not applicable to tuple structs")
-    }
-
-    if optional.optional {
-        syn_err_spanned!(field; "`optional` is not applicable to tuple fields")
-    }
-
-    if flatten {
-        syn_err_spanned!(field; "`flatten` is not applicable to tuple fields")
-    }
 
     formatted_fields.push(match type_override {
         Some(ref o) => quote!(#o.to_owned()),

--- a/macros/src/types/type_as.rs
+++ b/macros/src/types/type_as.rs
@@ -2,19 +2,12 @@ use quote::quote;
 use syn::{Result, Type};
 
 use crate::{
-    attr::{EnumAttr, StructAttr},
+    attr::{EnumAttr, StructAttr, ContainerAttr},
     deps::Dependencies,
     DerivedTS,
 };
 
 pub(crate) fn type_as_struct(attr: &StructAttr, name: &str, type_as: &Type) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not compatible with `as`");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not compatible with `as`");
-    }
-
     let crate_rename = attr.crate_rename();
 
     Ok(DerivedTS {
@@ -32,25 +25,6 @@ pub(crate) fn type_as_struct(attr: &StructAttr, name: &str, type_as: &Type) -> R
 }
 
 pub(crate) fn type_as_enum(attr: &EnumAttr, name: &str, type_as: &Type) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not compatible with `as`");
-    }
-    if attr.rename_all_fields.is_some() {
-        syn_err!("`rename_all_fields` is not compatible with `as`");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not compatible with `as`");
-    }
-    if attr.content.is_some() {
-        syn_err!("`content` is not compatible with `as`");
-    }
-    if attr.untagged {
-        syn_err!("`untagged` is not compatible with `as`");
-    }
-    if attr.type_override.is_some() {
-        syn_err!("`type` is not compatible with `as`");
-    }
-
     let crate_rename = attr.crate_rename();
 
     Ok(DerivedTS {

--- a/macros/src/types/type_as.rs
+++ b/macros/src/types/type_as.rs
@@ -2,7 +2,7 @@ use quote::quote;
 use syn::{Result, Type};
 
 use crate::{
-    attr::{EnumAttr, StructAttr, ContainerAttr},
+    attr::{ContainerAttr, EnumAttr, StructAttr},
     deps::Dependencies,
     DerivedTS,
 };

--- a/macros/src/types/type_override.rs
+++ b/macros/src/types/type_override.rs
@@ -2,7 +2,7 @@ use quote::quote;
 use syn::Result;
 
 use crate::{
-    attr::{EnumAttr, StructAttr},
+    attr::{ContainerAttr, EnumAttr, StructAttr},
     deps::Dependencies,
     DerivedTS,
 };
@@ -12,13 +12,6 @@ pub(crate) fn type_override_struct(
     name: &str,
     type_override: &str,
 ) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not compatible with `type`");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not compatible with `type`");
-    }
-
     let crate_rename = attr.crate_rename();
 
     Ok(DerivedTS {
@@ -40,22 +33,6 @@ pub(crate) fn type_override_enum(
     name: &str,
     type_override: &str,
 ) -> Result<DerivedTS> {
-    if attr.rename_all.is_some() {
-        syn_err!("`rename_all` is not compatible with `type`");
-    }
-    if attr.rename_all_fields.is_some() {
-        syn_err!("`rename_all_fields` is not compatible with `type`");
-    }
-    if attr.tag.is_some() {
-        syn_err!("`tag` is not compatible with `type`");
-    }
-    if attr.content.is_some() {
-        syn_err!("`content` is not compatible with `type`");
-    }
-    if attr.untagged {
-        syn_err!("`untagged` is not compatible with `type`");
-    }
-
     let crate_rename = attr.crate_rename();
 
     Ok(DerivedTS {

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -1,7 +1,11 @@
 use quote::quote;
 use syn::Result;
 
-use crate::{attr::StructAttr, deps::Dependencies, DerivedTS};
+use crate::{
+    attr::{ContainerAttr, StructAttr},
+    deps::Dependencies,
+    DerivedTS,
+};
 
 pub(crate) fn empty_object(attr: &StructAttr, name: &str) -> Result<DerivedTS> {
     check_attributes(attr)?;

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -113,10 +113,10 @@ where
 /// Parse all `#[serde(..)]` attributes from the given slice.
 #[cfg(feature = "serde-compat")]
 #[allow(unused)]
-pub fn parse_serde_attrs<'a, A>(attrs: &'a [Attribute], initial: A) -> A
+pub fn parse_serde_attrs<'a, A>(attrs: &'a [Attribute]) -> Serde<A>
 where
     A: Attr,
-    Serde<A>: TryFrom<&'a Attribute, Error = Error> + Attr,
+    Serde<A>: TryFrom<&'a Attribute, Error = Error>,
 {
     use crate::attr::Serde;
 
@@ -139,7 +139,7 @@ where
                 None
             }
         })
-        .fold(initial, |acc, cur| acc.merge(cur.0))
+        .fold(Serde::<A>::default(), |acc, cur| acc.merge(cur))
 }
 
 /// Return doc comments parsed and formatted as JSDoc.

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -7,6 +7,7 @@ use syn::{
     Result, Type,
 };
 
+use super::attr::Attr;
 use crate::deps::Dependencies;
 
 macro_rules! syn_err {
@@ -96,16 +97,17 @@ pub fn raw_name_to_ts_field(value: String) -> String {
 }
 
 /// Parse all `#[ts(..)]` attributes from the given slice.
-pub fn parse_attrs<'a, A>(attrs: &'a [Attribute]) -> Result<impl Iterator<Item = A>>
+pub fn parse_attrs<'a, A>(attrs: &'a [Attribute]) -> Result<A>
 where
-    A: TryFrom<&'a Attribute, Error = Error>,
+    A: TryFrom<&'a Attribute, Error = Error> + Attr,
 {
     Ok(attrs
         .iter()
         .filter(|a| a.path().is_ident("ts"))
         .map(A::try_from)
         .collect::<Result<Vec<A>>>()?
-        .into_iter())
+        .into_iter()
+        .fold(A::default(), |acc, cur| acc.merge(cur)))
 }
 
 /// Parse all `#[serde(..)]` attributes from the given slice.

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -7,7 +7,7 @@ use syn::{
     Result, Type,
 };
 
-use super::attr::Attr;
+use super::attr::{Attr, Serde};
 use crate::deps::Dependencies;
 
 macro_rules! syn_err {
@@ -26,16 +26,16 @@ macro_rules! syn_err_spanned {
 }
 
 macro_rules! impl_parse {
-    ($i:ident ($input:ident, $out:ident) { $($k:pat => $e:expr),* $(,)? }) => {
-        impl std::convert::TryFrom<&syn::Attribute> for $i {
+    ($i:ident $(<$inner: ident>)? ($input:ident, $out:ident) { $($k:pat => $e:expr),* $(,)? }) => {
+        impl std::convert::TryFrom<&syn::Attribute> for $i $(<$inner>)? {
             type Error = syn::Error;
 
             fn try_from(attr: &syn::Attribute) -> syn::Result<Self> { attr.parse_args() }
         }
 
-        impl syn::parse::Parse for $i {
+        impl syn::parse::Parse for $i $(<$inner>)? {
             fn parse($input: syn::parse::ParseStream) -> syn::Result<Self> {
-                let mut $out = $i::default();
+                let mut $out = Self::default();
                 loop {
                     let span = $input.span();
                     let key: Ident = $input.call(syn::ext::IdentExt::parse_any)?;
@@ -113,13 +113,17 @@ where
 /// Parse all `#[serde(..)]` attributes from the given slice.
 #[cfg(feature = "serde-compat")]
 #[allow(unused)]
-pub fn parse_serde_attrs<'a, A: TryFrom<&'a Attribute, Error = Error>>(
-    attrs: &'a [Attribute],
-) -> impl Iterator<Item = A> {
+pub fn parse_serde_attrs<'a, A>(attrs: &'a [Attribute], initial: A) -> A
+where
+    A: Attr,
+    Serde<A>: TryFrom<&'a Attribute, Error = Error> + Attr,
+{
+    use crate::attr::Serde;
+
     attrs
         .iter()
         .filter(|a| a.path().is_ident("serde"))
-        .flat_map(|attr| match A::try_from(attr) {
+        .flat_map(|attr| match Serde::<A>::try_from(attr) {
             Ok(attr) => Some(attr),
             Err(_) => {
                 #[cfg(not(feature = "no-serde-warnings"))]
@@ -135,8 +139,7 @@ pub fn parse_serde_attrs<'a, A: TryFrom<&'a Attribute, Error = Error>>(
                 None
             }
         })
-        .collect::<Vec<_>>()
-        .into_iter()
+        .fold(initial, |acc, cur| acc.merge(cur.0))
 }
 
 /// Return doc comments parsed and formatted as JSDoc.

--- a/ts-rs/tests/serde-skip-with-default.rs
+++ b/ts-rs/tests/serde-skip-with-default.rs
@@ -12,7 +12,7 @@ fn default_http_version() -> String {
 #[derive(Debug, Clone, Deserialize, Serialize, TS)]
 #[ts(export, export_to = "serde_skip_with_default/")]
 pub struct Foobar {
-    #[ts(skip)]
+    // #[ts(skip)]
     #[serde(skip, default = "default_http_version")]
     pub http_version: String,
     pub something_else: i32,


### PR DESCRIPTION
## Goal

This PR aims to change the way we parse attributes in a few key ways:
- Introducing a couple of traits for the methods all attribute types share
- Change the `merge` method to remove the mutable reference
  - The reasoning for this is mostly that I think a `for_each` that mutates external data is somewhat confusing, so I changed it to use `fold` (think JS `Array.protoype.reduce`) instead.
- Bring all the attribute compatibility validation to the same file where parsing is done

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
  - This is a refactor, so there isn't really new anything I can test... We could make tests for whether or not our compiler errors are correct, but we still have to figure out how to do that
