### PR TITLE
Fix inconsistencies with `serde` and add `SCREAMING-KEBAB-CASE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ### Breaking
 
+- Fix incompatibility with serde for `snake_case`, `kebab-case` and `SCREAMING_SNAKE_CASE` ([#298](https://github.com/Aleph-Alpha/ts-rs/pull/298))
+- `#[ts(rename_all = "...")]` no longer accepts variations in the string's casing, dashes and underscores to make behavior consistent with serde ([#298](https://github.com/Aleph-Alpha/ts-rs/pull/298))
+
 ### Features
 
 - Add support for `#[ts(type = "..")]` directly on structs and enums ([#286](https://github.com/Aleph-Alpha/ts-rs/pull/286))
 - Add support for `#[ts(as = "..")]` directly on structs and enums ([#288](https://github.com/Aleph-Alpha/ts-rs/pull/288))
+- Add support for `#[ts(rename_all = "SCREAMING-KEBAB-CASE")]` ([#298](https://github.com/Aleph-Alpha/ts-rs/pull/298))
 
 ### Fixes
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -19,5 +19,4 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2.0.28", features = ["full", "extra-traits"] }
-Inflector = { version = "0.11", default-features = false }
 termcolor = { version = "1", optional = true }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -2,7 +2,10 @@ use std::collections::HashMap;
 
 use syn::{parse_quote, Attribute, Fields, Ident, Path, Result, Type, WherePredicate};
 
-use super::{parse_assign_from_str, parse_bound, parse_concrete, Attr, ContainerAttr, Serde};
+use super::{
+    parse_assign_from_str, parse_assign_inflection, parse_bound, parse_concrete, Attr,
+    ContainerAttr, Serde,
+};
 use crate::{
     attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
     utils::{parse_attrs, parse_docs},
@@ -35,7 +38,7 @@ impl StructAttr {
 
         let docs = parse_docs(attrs)?;
         result.docs = docs;
-        
+
         Ok(result)
     }
 
@@ -133,7 +136,7 @@ impl_parse! {
         "as" => out.type_as = Some(parse_assign_from_str(input)?),
         "type" => out.type_override = Some(parse_assign_str(input)?),
         "rename" => out.rename = Some(parse_assign_str(input)?),
-        "rename_all" => out.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
+        "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
         "tag" => out.tag = Some(parse_assign_str(input)?),
         "export" => out.export = true,
         "export_to" => out.export_to = Some(parse_assign_str(input)?),
@@ -146,7 +149,7 @@ impl_parse! {
 impl_parse! {
     Serde<StructAttr>(input, out) {
         "rename" => out.0.rename = Some(parse_assign_str(input)?),
-        "rename_all" => out.0.rename_all = Some(parse_assign_str(input).and_then(Inflection::try_from)?),
+        "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "tag" => out.0.tag = Some(parse_assign_str(input)?),
         "bound" => out.0.bound = Some(parse_bound(input)?),
         // parse #[serde(default)] to not emit a warning

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -36,12 +36,13 @@ import-esm = []
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 
 [dependencies]
 heapless = { version = ">= 0.7, < 0.9", optional = true }
 ts-rs-macros = { version = "=8.1.0", path = "../macros" }
-dprint-plugin-typescript = { version = "0.89", optional = true }
+dprint-plugin-typescript = { version = "0.90", optional = true }
 chrono = { version = "0.4", optional = true }
 bigdecimal = { version = ">= 0.0.13, < 0.5", features = [
   "serde",

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -220,7 +220,7 @@ pub mod typelist;
 ///
 /// - **`#[ts(rename_all = "..")]`**  
 ///   Rename all fields/variants of the type.  
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 ///
 /// - **`#[ts(concrete(..)]`**  
@@ -336,13 +336,13 @@ pub mod typelist;
 ///
 /// - **`#[ts(rename_all = "..")]`**  
 ///   Rename all variants of this enum.  
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 ///
 /// - **`#[ts(rename_all_fieds = "..")]`**  
 ///   Renames the fields of all the struct variants of this enum. This is equivalent to using
 ///   `#[ts(rename_all = "..")]` on all of the enum's variants.
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 ///  
 /// ### enum variant attributes
@@ -362,7 +362,7 @@ pub mod typelist;
 ///
 /// - **`#[ts(rename_all = "..")]`**  
 ///   Renames all the fields of a struct variant.
-///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case"
+///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 pub trait TS {
     /// If this type does not have generic parameters, then `WithoutGenerics` should just be `Self`.

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -61,8 +61,11 @@ struct RenameAllScreamingKebab {
 
 #[test]
 fn rename_all_screaming_kebab_case() {
-    // let a = RenameAllScreamingKebab::default();
-    // assert_eq!(serde_json::to_string(&a).unwrap(), "");
+    let rename_all = RenameAllScreamingKebab::default();
+    assert_eq!(
+        serde_json::to_string(&rename_all).unwrap(),
+        r#"{"CRC32C-HASH":0,"SOME-FIELD":0,"SOME-OTHER-FIELD":0}"#
+    );
     assert_eq!(
         RenameAllScreamingKebab::inline(),
         r#"{ "CRC32C-HASH": number, "SOME-FIELD": number, "SOME-OTHER-FIELD": number, }"#

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -46,6 +46,29 @@ fn rename_all_pascal_case() {
     );
 }
 
+#[derive(TS, Default, serde::Serialize)]
+#[ts(
+    export,
+    export_to = "struct_rename/",
+    rename_all = "SCREAMING-KEBAB-CASE"
+)]
+#[serde(rename_all = "SCREAMING-KEBAB-CASE")]
+struct RenameAllScreamingKebab {
+    crc32c_hash: i32,
+    some_field: i32,
+    some_other_field: i32,
+}
+
+#[test]
+fn rename_all_screaming_kebab_case() {
+    // let a = RenameAllScreamingKebab::default();
+    // assert_eq!(serde_json::to_string(&a).unwrap(), "");
+    assert_eq!(
+        RenameAllScreamingKebab::inline(),
+        r#"{ "CRC32C-HASH": number, "SOME-FIELD": number, "SOME-OTHER-FIELD": number, }"#
+    );
+}
+
 #[derive(serde::Serialize, TS)]
 #[ts(export, export_to = "struct_rename/", rename_all = "camelCase")]
 struct RenameSerdeSpecialChar {

--- a/ts-rs/tests/struct_rename.rs
+++ b/ts-rs/tests/struct_rename.rs
@@ -47,12 +47,9 @@ fn rename_all_pascal_case() {
 }
 
 #[derive(TS, Default, serde::Serialize)]
-#[ts(
-    export,
-    export_to = "struct_rename/",
-    rename_all = "SCREAMING-KEBAB-CASE"
-)]
-#[serde(rename_all = "SCREAMING-KEBAB-CASE")]
+#[ts(export, export_to = "struct_rename/")]
+#[cfg_attr(feature = "serde-compat", serde(rename_all = "SCREAMING-KEBAB-CASE"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "SCREAMING-KEBAB-CASE"))]
 struct RenameAllScreamingKebab {
     crc32c_hash: i32,
     some_field: i32,


### PR DESCRIPTION
## Goal

This PR aims to fix a few inconsistencies with `serde` caused by our use of `inflector`:
- Fix `snake_case` inconsistency
- Fix `SCREAMING_SNAKE_CASE` inconsistency
- Fix `kebab-case` inconsistency
- Add `SCREMING-KEBAB-CASE`
- Remove dependency on `inflector`
- `serde` only accepts the `rename_all` rule if the case is written exactly as described (i.e. `CAMELCASE`, `Kebab-case`, etc. are not allowed), where as `ts` accepts any changes in case, dashes and underscores. This was changed for consistency with `serde`

Closes #297

## Changes

- Manually implement `snake_case` like in `serde`
- Change `parse_assign_inflection` to only accept cases written strictly like in the docs
- Add `Inflection::ScreamingKebab`
- Remove dependency on `inflector`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
