### PR TITLE
Fix location of rename_all errors

### DIFF
--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -137,25 +137,27 @@ fn parse_concrete(input: ParseStream) -> Result<HashMap<syn::Ident, syn::Type>> 
 }
 
 fn parse_assign_inflection(input: ParseStream) -> Result<Inflection> {
-    let span = input.span();
-    let str = parse_assign_str(input)?;
+    input.parse::<Token![=]>()?;
 
-    Ok(match &*str {
-        "lowercase" => Inflection::Lower,
-        "UPPERCASE" => Inflection::Upper,
-        "camelCase" => Inflection::Camel,
-        "snake_case" => Inflection::Snake,
-        "PascalCase" => Inflection::Pascal,
-        "SCREAMING_SNAKE_CASE" => Inflection::ScreamingSnake,
-        "kebab-case" => Inflection::Kebab,
-        "SCREAMING-KEBAB-CASE" => Inflection::ScreamingKebab,
-        other => {
-            syn_err!(
-                span;
-                r#"Value "{other}" is not valid for "rename_all". Accepted values are: "lowercase", "UPPERCASE", "camelCase", "snake_case", "PascalCase", "SCREAMING_SNAKE_CASE", "kebab-case" and "SCREAMING-KEBAB-CASE""#
-            )
-        }
-    })
+    match Lit::parse(input)? {
+        Lit::Str(string) => Ok(match &*string.value() {
+            "lowercase" => Inflection::Lower,
+            "UPPERCASE" => Inflection::Upper,
+            "camelCase" => Inflection::Camel,
+            "snake_case" => Inflection::Snake,
+            "PascalCase" => Inflection::Pascal,
+            "SCREAMING_SNAKE_CASE" => Inflection::ScreamingSnake,
+            "kebab-case" => Inflection::Kebab,
+            "SCREAMING-KEBAB-CASE" => Inflection::ScreamingKebab,
+            other => {
+                syn_err!(
+                    string.span();
+                    r#"Value "{other}" is not valid for "rename_all". Accepted values are: "lowercase", "UPPERCASE", "camelCase", "snake_case", "PascalCase", "SCREAMING_SNAKE_CASE", "kebab-case" and "SCREAMING-KEBAB-CASE""#
+                )
+            }
+        }),
+        other => Err(Error::new(other.span(), "expected string")),
+    }
 }
 
 fn parse_assign_from_str<T>(input: ParseStream) -> Result<T>

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -103,7 +103,7 @@ fn format_field(
         docs,
 
         #[cfg(feature = "serde-compat")]
-        using_serde_with: _,
+            using_serde_with: _,
     } = field_attr;
 
     if skip {

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -60,7 +60,7 @@ fn format_field(
         docs: _,
 
         #[cfg(feature = "serde-compat")]
-        using_serde_with: _,
+            using_serde_with: _,
     } = field_attr;
 
     if skip {


### PR DESCRIPTION
## Goal

After #298 errors in `rename_all` were pointing at the `=` token instead of the attribute value, this PR fixes that mistake

## Changes

Changed `parse_assign_inflection` to get the correct `Span`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
