### PR TITLE
Fix missing case in #299

### DIFF
--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -1,5 +1,5 @@
 use syn::{
-    AngleBracketedGenericArguments, Attribute, Field, GenericArgument, Ident, PathArguments,
+    AngleBracketedGenericArguments, Attribute, Field, GenericArgument, Ident, PathArguments, QSelf,
     Result, ReturnType, Type, TypeArray, TypeGroup, TypeParen, TypePath, TypePtr, TypeReference,
     TypeSlice, TypeTuple,
 };
@@ -232,7 +232,11 @@ fn replace_underscore(ty: &mut Type, with: &Type) {
                 replace_underscore(elem, with);
             }
         }
-        Type::Path(TypePath { path, qself: None }) => {
+        Type::Path(TypePath { path, qself }) => {
+            if let Some(QSelf { ty, .. }) = qself {
+                replace_underscore(ty, with);
+            }
+
             for segment in &mut path.segments {
                 match &mut segment.arguments {
                     PathArguments::None => (),

--- a/ts-rs/tests/integration/infer_as.rs
+++ b/ts-rs/tests/integration/infer_as.rs
@@ -2,14 +2,28 @@
 
 use ts_rs::TS;
 
+trait Bar {
+    type Baz;
+}
+
+impl Bar for String {
+    type Baz = i32;
+}
+
 #[derive(TS)]
 #[ts(export)]
 struct Foo {
     #[ts(optional, as = "Option<_>")]
     my_optional_bool: bool,
+
+    #[ts(as = "<_ as Bar>::Baz")]
+    q_self: String,
 }
 
 #[test]
 fn test() {
-    assert_eq!(Foo::inline(), "{ my_optional_bool?: boolean, }");
+    assert_eq!(
+        Foo::inline(),
+        "{ my_optional_bool?: boolean, q_self: number, }"
+    );
 }


### PR DESCRIPTION
## Goal

In #299, the `type_as_infer` (now called `replace_underscore`) function doesn't handle a type `Type::Path(TypePath { qself: Some(_), .. })` due to a match on `None` for the `qself` field, this PR is a quick fix for that

This allows the following use of `as`:
```rs
#[ts(as = "<_ as Bar>::Baz")]
foo: String
```

## Changes

Removed the match on `qself: None` and called `replace_underscore` on `qself.ty`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
