### PR TITLE
Coerce passed type to TS before invoking ::name()

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -625,7 +625,7 @@ macro_rules! impl_tuples {
         impl<$($i: TS),*> TS for ($($i,)*) {
             type WithoutGenerics = (Dummy, );
             fn name() -> String {
-                format!("[{}]", [$($i::name()),*].join(", "))
+                format!("[{}]", [$(<$i as $crate::TS>::name()),*].join(", "))
             }
             fn inline() -> String {
                 panic!("tuple cannot be inlined!");


### PR DESCRIPTION
If we're running the macro on a type which has an in-scope trait containing a `::name` member, the compiler will not know which to invoke.

This clarifies that in the macro's context, we want to invoke the TS::name trait method by first casting the argument to the TS trait.

This pattern is in some other parts of the macro, I think this one was just triggered previously.

## Goal

What is this PR attempting to achieve? Is it a bug fix? Is it related to an issue?
Closes #

## Changes

How did you go about solving the problem?

## Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
