### PR TITLE
Fix error in internally tagged enums with flattened fields

### DIFF
--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -4,7 +4,7 @@ use syn::{parse_quote, Attribute, Fields, Ident, Path, Result, Type, WherePredic
 
 use super::{
     parse_assign_from_str, parse_assign_inflection, parse_bound, parse_concrete, Attr,
-    ContainerAttr, Serde,
+    ContainerAttr, Serde, Tagged,
 };
 use crate::{
     attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
@@ -53,6 +53,17 @@ impl StructAttr {
                 Fields::Named(_) => enum_attr.rename_all_fields,
                 Fields::Unnamed(_) | Fields::Unit => None,
             }),
+            tag: match variant_fields {
+                Fields::Named(_) => match enum_attr
+                    .tagged()
+                    .expect("The variant attribute is known to be valid at this point")
+                {
+                    Tagged::Internally { tag } => Some(tag.to_owned()),
+                    _ => None,
+                },
+                _ => None,
+            },
+
             // inline and skip are not supported on StructAttr
             ..Self::default()
         }

--- a/macros/src/types/mod.rs
+++ b/macros/src/types/mod.rs
@@ -1,8 +1,7 @@
-use syn::{Fields, Ident, ItemStruct, Result};
+use syn::{Fields, ItemStruct, Result};
 
 use crate::{
     attr::{Attr, StructAttr},
-    utils::to_ts_ident,
     DerivedTS,
 };
 
@@ -19,13 +18,16 @@ pub(crate) use r#enum::r#enum_def;
 pub(crate) fn struct_def(s: &ItemStruct) -> Result<DerivedTS> {
     let attr = StructAttr::from_attrs(&s.attrs)?;
 
-    type_def(&attr, &s.ident, &s.fields)
+    type_def(&attr, &s.ident.to_string(), &s.fields)
 }
 
-fn type_def(attr: &StructAttr, ident: &Ident, fields: &Fields) -> Result<DerivedTS> {
+fn type_def(attr: &StructAttr, ident: &str, fields: &Fields) -> Result<DerivedTS> {
     attr.assert_validity(fields)?;
 
-    let name = attr.rename.clone().unwrap_or_else(|| to_ts_ident(ident));
+    let name = attr
+        .rename
+        .clone()
+        .unwrap_or_else(|| ident.trim_start_matches("r#").to_owned());
     if let Some(attr_type_override) = &attr.type_override {
         return type_override::type_override_struct(attr, &name, attr_type_override);
     }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -19,7 +19,7 @@ pub(crate) fn named(attr: &StructAttr, name: &str, fields: &FieldsNamed) -> Resu
     let mut dependencies = Dependencies::new(crate_rename.clone());
 
     if let Some(tag) = &attr.tag {
-        let formatted = format!("{}: \"{}\",", tag, name);
+        let formatted = format!("\"{}\": \"{}\",", tag, name);
         formatted_fields.push(quote! {
             #formatted.to_string()
         });
@@ -42,7 +42,13 @@ pub(crate) fn named(attr: &StructAttr, name: &str, fields: &FieldsNamed) -> Resu
     let inline = match (formatted_fields.len(), flattened_fields.len()) {
         (0, 0) => quote!("{  }".to_owned()),
         (_, 0) => quote!(format!("{{ {} }}", #fields)),
-        (0, 1) => quote!(#flattened.trim_matches(|c| c == '(' || c == ')').to_owned()),
+        (0, 1) => quote! {{
+            if #flattened.starts_with('(') && #flattened.ends_with(')') {
+                #flattened[1..#flattened.len() - 1].trim().to_owned()
+            } else {
+                #flattened.trim().to_owned()
+            }
+        }},
         (0, _) => quote!(#flattened),
         (_, _) => quote!(format!("{{ {} }} & {}", #fields, #flattened)),
     };

--- a/ts-rs/tests/integration/complex_flattened_type.rs
+++ b/ts-rs/tests/integration/complex_flattened_type.rs
@@ -1,0 +1,50 @@
+use ts_rs::TS;
+
+/// Defines the type of input and its intial fields
+#[derive(TS)]
+#[ts(tag = "input_type")]
+pub enum InputType {
+    Text,
+    Expression,
+    Number {
+        min: Option<isize>,
+        max: Option<isize>,
+    },
+    Dropdown {
+        options: Vec<(String, String)>,
+    },
+}
+
+#[derive(TS)]
+#[ts(tag = "type")]
+pub enum InputFieldElement {
+    Label {
+        text: String,
+    },
+    Input {
+        #[ts(flatten)]
+        input: InputType,
+        name: Option<String>,
+        placeholder: Option<String>,
+        default: Option<String>,
+    },
+}
+
+#[derive(TS)]
+#[ts(export, export_to = "complex_flattened_type/")]
+pub struct InputField {
+    #[ts(flatten)]
+    r#type: InputFieldElement,
+}
+
+#[test]
+fn complex_flattened_type() {
+    assert_eq!(
+        InputFieldElement::decl(),
+        r#"type InputFieldElement = { "type": "Label", text: string, } | { "type": "Input", name: string | null, placeholder: string | null, default: string | null, } & ({ "input_type": "Text" } | { "input_type": "Expression" } | { "input_type": "Number", min: number | null, max: number | null, } | { "input_type": "Dropdown", options: Array<[string, string]>, });"#
+    );
+    assert_eq!(
+        InputField::decl(),
+        r#"type InputField = { "type": "Label", text: string, } | { "type": "Input", name: string | null, placeholder: string | null, default: string | null, } & ({ "input_type": "Text" } | { "input_type": "Expression" } | { "input_type": "Number", min: number | null, max: number | null, } | { "input_type": "Dropdown", options: Array<[string, string]>, });"#
+    )
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -4,6 +4,7 @@ mod arrays;
 mod bound;
 mod bson;
 mod chrono;
+mod complex_flattened_type;
 mod concrete_generic;
 mod docs;
 mod enum_flattening;

--- a/ts-rs/tests/integration/skip.rs
+++ b/ts-rs/tests/integration/skip.rs
@@ -88,7 +88,7 @@ enum Internally {
 fn internally_tagged() {
     assert_eq!(
         Internally::decl(),
-        r#"type Internally = { "t": "A" } | { "t": "B",  } | { "t": "C", y: number, };"#
+        r#"type Internally = { "t": "A" } | { "t": "B", } | { "t": "C", y: number, };"#
     );
 }
 

--- a/ts-rs/tests/integration/struct_tag.rs
+++ b/ts-rs/tests/integration/struct_tag.rs
@@ -17,6 +17,6 @@ struct TaggedType {
 fn test() {
     assert_eq!(
         TaggedType::inline(),
-        "{ type: \"TaggedType\", a: number, b: number, }"
+        "{ \"type\": \"TaggedType\", a: number, b: number, }"
     )
 }

--- a/ts-rs/tests/integration/union_named_serde_skip.rs
+++ b/ts-rs/tests/integration/union_named_serde_skip.rs
@@ -81,6 +81,6 @@ fn test() {
 
     assert_eq!(
         TestInternally::decl(),
-        r#"type TestInternally = { "type": "A" } | { "type": "B" } | { "type": "C",  };"#
+        r#"type TestInternally = { "type": "A" } | { "type": "B" } | { "type": "C", };"#
     );
 }


### PR DESCRIPTION
## Goal

Fix internally tagged enum with struct variant containing inlined field
Closes #343

## Changes

Instead of attempting to format the variant in the `format_variant` function, allow `type_def` to generate a fully formatted variant by giving it the variant's name and tag

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
