### PR TITLE
Always use forward slash on import paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,7 @@ jobs:
           cargo test --all-features
           "{}" | Out-File bindings/tsconfig.json
           cd bindings
+          npm -i -g typescript
           tsc --noEmit --noUnusedLocals --strict
           cd ..
           rm -r -fo bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,3 +163,26 @@ jobs:
           shopt -s globstar
           tsc bindings/**/*.ts --noEmit --noUnusedLocals
           rm -rf bindings
+
+  test-windows:
+    name: Test ts-rs with --all-features on Windows
+    runs-on: windows-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test
+        working-directory: ts-rs
+        # Create empty tsconfig and cd into bindings to make tsc
+        # compile every ts file in the directory
+        run: |
+          cargo test --all-features
+          "{}" | Out-File bindings/tsconfig.json
+          cd bindings
+          tsc --noEmit --noUnusedLocals --strict
+          cd ..
+          rm -r -fo bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
           cargo test --all-features
           "{}" | Out-File bindings/tsconfig.json
           cd bindings
-          npm -i -g typescript
+          npm i -g typescript
           tsc --noEmit --noUnusedLocals --strict
           cd ..
           rm -r -fo bindings

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 /.idea
 *.ts
+tsconfig.json
 
 /ts-rs/tests-out


### PR DESCRIPTION
## Goal

This PR changes import paths such that they will always use forward slash `/` as the path separator, even on Windows. It also adds a windows test run to the CI
Closes #345

## Changes

If `target_os = "windows"`, replace `\` with `/`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
