### PR TITLE
Proof of concept, argument  to `export_to` other than  `&'static str`

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -6,6 +6,7 @@ use super::{parse_assign_from_str, parse_bound, Attr, ContainerAttr, Serde};
 use crate::{
     attr::{parse_assign_inflection, parse_assign_str, parse_concrete, Inflection},
     utils::{parse_attrs, parse_docs},
+    path::CustomPath,
 };
 
 #[derive(Default)]
@@ -16,7 +17,7 @@ pub struct EnumAttr {
     pub rename_all: Option<Inflection>,
     pub rename_all_fields: Option<Inflection>,
     pub rename: Option<String>,
-    pub export_to: Option<String>,
+    pub export_to: Option<CustomPath>,
     pub export: bool,
     pub docs: String,
     pub concrete: HashMap<Ident, Type>,
@@ -212,7 +213,7 @@ impl_parse! {
         "rename" => out.rename = Some(parse_assign_str(input)?),
         "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
         "rename_all_fields" => out.rename_all_fields = Some(parse_assign_inflection(input)?),
-        "export_to" => out.export_to = Some(parse_assign_str(input)?),
+        "export_to" => out.export_to = Some(CustomPath::parse(input)?),
         "export" => out.export = true,
         "tag" => out.tag = Some(parse_assign_str(input)?),
         "content" => out.content = Some(parse_assign_str(input)?),

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -5,8 +5,8 @@ use syn::{parse_quote, Attribute, Ident, ItemEnum, Path, Result, Type, WherePred
 use super::{parse_assign_from_str, parse_bound, Attr, ContainerAttr, Serde};
 use crate::{
     attr::{parse_assign_inflection, parse_assign_str, parse_concrete, Inflection},
-    utils::{parse_attrs, parse_docs},
     path::CustomPath,
+    utils::{parse_attrs, parse_docs},
 };
 
 #[derive(Default)]

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
     utils::{parse_attrs, parse_docs},
+    path::CustomPath,
 };
 
 #[derive(Default, Clone)]
@@ -18,7 +19,7 @@ pub struct StructAttr {
     pub type_override: Option<String>,
     pub rename_all: Option<Inflection>,
     pub rename: Option<String>,
-    pub export_to: Option<String>,
+    pub export_to: Option<CustomPath>,
     pub export: bool,
     pub tag: Option<String>,
     pub docs: String,
@@ -149,7 +150,7 @@ impl_parse! {
         "rename_all" => out.rename_all = Some(parse_assign_inflection(input)?),
         "tag" => out.tag = Some(parse_assign_str(input)?),
         "export" => out.export = true,
-        "export_to" => out.export_to = Some(parse_assign_str(input)?),
+        "export_to" => out.export_to = Some(CustomPath::parse(input)?),
         "concrete" => out.concrete = parse_concrete(input)?,
         "bound" => out.bound = Some(parse_bound(input)?),
     }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -8,8 +8,8 @@ use super::{
 };
 use crate::{
     attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
-    utils::{parse_attrs, parse_docs},
     path::CustomPath,
+    utils::{parse_attrs, parse_docs},
 };
 
 #[derive(Default, Clone)]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -11,14 +11,14 @@ use syn::{
     WhereClause, WherePredicate,
 };
 
-use crate::{deps::Dependencies, utils::format_generics, path::CustomPath};
+use crate::{deps::Dependencies, path::CustomPath, utils::format_generics};
 
 #[macro_use]
 mod utils;
 mod attr;
 mod deps;
-mod types;
 mod path;
+mod types;
 
 struct DerivedTS {
     crate_rename: Path,
@@ -39,11 +39,9 @@ impl DerivedTS {
         let export = self
             .export
             .then(|| self.generate_export_test(&rust_ty, &generics));
-        
-        let output_path_fn = {
-            let (path,path_decl) = 
 
-            if let Some(cust_path) = &self.export_to{
+        let output_path_fn = {
+            let (path, path_decl) = if let Some(cust_path) = &self.export_to {
                 cust_path.get_path_and_some_decl(&self.ts_name)
             } else {
                 let path = format!("{}.ts", self.ts_name);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -11,13 +11,14 @@ use syn::{
     WhereClause, WherePredicate,
 };
 
-use crate::{deps::Dependencies, utils::format_generics};
+use crate::{deps::Dependencies, utils::format_generics, path::CustomPath};
 
 #[macro_use]
 mod utils;
 mod attr;
 mod deps;
 mod types;
+mod path;
 
 struct DerivedTS {
     crate_rename: Path,
@@ -30,7 +31,7 @@ struct DerivedTS {
     bound: Option<Vec<WherePredicate>>,
 
     export: bool,
-    export_to: Option<String>,
+    export_to: Option<CustomPath>,
 }
 
 impl DerivedTS {
@@ -38,18 +39,20 @@ impl DerivedTS {
         let export = self
             .export
             .then(|| self.generate_export_test(&rust_ty, &generics));
-
+        
         let output_path_fn = {
-            let path = match self.export_to.as_deref() {
-                Some(dirname) if dirname.ends_with('/') => {
-                    format!("{}{}.ts", dirname, self.ts_name)
-                }
-                Some(filename) => filename.to_owned(),
-                None => format!("{}.ts", self.ts_name),
+            let (path,path_decl) = 
+
+            if let Some(cust_path) = &self.export_to{
+                cust_path.get_path_and_some_decl(&self.ts_name)
+            } else {
+                let path = format!("{}.ts", self.ts_name);
+                (quote!( #path ), None)
             };
 
             quote! {
                 fn output_path() -> Option<&'static std::path::Path> {
+                    #path_decl
                     Some(std::path::Path::new(#path))
                 }
             }

--- a/macros/src/path.rs
+++ b/macros/src/path.rs
@@ -1,113 +1,48 @@
-use quote::{format_ident, quote};
 use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 use syn::{
     parse::{Parse, ParseStream},
-    Error, Lit, Ident,LitStr, Token, Result,
+    Error, Ident, Lit, LitStr, Result, Token,
 };
 
 
-#[derive(Clone,Debug)]
-pub enum CustomPath{
-    Str(String),
-    Static(syn::Path), 
-    Fn(syn::Path),  
-    Env(syn::LitStr),     
-}
+const PATH_CONVENTION_MSG: &'static str = r###"
+Remider on `TS` trait export path convention.
 
-type FnOutputPathBody = ( TokenStream, Option<TokenStream> );
+#[ts(export)]
 
-impl CustomPath {
-    
-    pub fn get_path_and_some_decl(&self, ts_name: &String ) -> FnOutputPathBody {
+    Generates a test which will export the type, by default to bindings/<name>.ts when running cargo test.
+    The default base directory can be overridden with the `TS_RS_EXPORT_DIR` environment variable. Adding the variable to a project's config.toml can make it easier to manage.
 
-        match self {
 
-            Self::Str(input) => { Self::str_path(input,ts_name) },
+# <project-root>/.cargo/config.toml
+[env]
+TS_RS_EXPORT_DIR = { value = "<OVERRIDE_DIR>", relative = true }
 
-            Self::Static(input) => { Self::static_path(input,ts_name) },
 
-            Self::Fn(input) => { Self::fn_path(input,ts_name) },
+#[ts(export_to = "..")]
 
-            Self::Env(input) => { Self::env_path(input,ts_name) },
+    Specifies where the type should be exported to. Defaults to <name>.ts.
+    The path given to the export_to attribute is relative to the `TS_RS_EXPORT_DIR` environment variable, or, if `TS_RS_EXPORT_DIR` is not set, to ./bindings .
+    If the provided path ends in a trailing /, it is interpreted as a directory.
+    Note that you need to add the 'export' attribute as well, in order to generate a test which exports the type.
+"###;
 
-        } 
-    }
+// If the crate MSRV is increased to 1.70.0 than the 'Note ' from point 4 should be removed !
 
-    fn str_path( input: &String, ts_name: &String ) -> FnOutputPathBody {
+const PARSING_ERROR_MSG: &'static str =
 
-        let path = 
-        if input.ends_with('/') {
-            format!("{}{}.ts", input, ts_name)
-        }  else {
-            input.to_owned()
-        };
+"`export_to` expects as arguments the following types:
 
-        return (quote!(#path),None);
-    }
+1) string literal
+    #[ts(export_to = \"my/path\")]
 
-    fn static_path( input: &syn::Path, ts_name: &String ) -> FnOutputPathBody {
-
-        let path_ident      = format_ident!("path");
-        let stat_path_ident = format_ident!("PATH");
-        let path_decl = quote! {
-
-            static #stat_path_ident: std::sync::OnceLock<String> = std::sync::OnceLock::new();
-        
-            let #path_ident = #stat_path_ident.get_or_init( ||
-                {
-                    if #input.ends_with('/')  {
-                        format!("{}{}.ts", #input, #ts_name)
-                    } else {
-                        format!("{}",#input)
-                    }
-                } 
-            );
-        };
-
-        ( quote!(#path_ident), Some(path_decl) )
-    }
-
-    fn fn_path( input: &syn::Path, ts_name: &String ) -> FnOutputPathBody { 
-        
-        ( quote!{#input (#ts_name)?}, None)
-    }
-
-    fn env_path( input: &LitStr, ts_name: &String ) -> FnOutputPathBody {
-
-        let path_ident = format_ident!("path");
-
-        let path_decl = quote!{
-
-            let #path_ident = if std::env!(#input).ends_with('/') {
-                std::concat!(std::env!(#input),#ts_name,".ts")
-            } else {
-                std::env!(#input)
-            };
-        };
-
-        ( quote!(#path_ident), Some(path_decl) )
-    }
-
-}
-
-impl Parse for CustomPath {
-
-    fn parse(input: ParseStream) -> Result<CustomPath> {
-        input.parse::<Token![=]>()?;
-        let span = input.span();
-
-        let msg = 
-"expected arguments for 'export_to':
-
-1) string literal 
-    #[ts(export_to = \"my/path\")] 
-
-2) static or constant variable name 
+2) static or constant variable name
 
     #[ts(export_to = MY_STATIC_PATH)]
     #[ts(export_to = crate::MY_STATIC_PATH)]
 
-Note: This option is available for Rust 1.7.0 and higher!
+Note: This option is available for Rust 1.70.0 and higher!
 
 3) function name of a `Fn(&'static str) -> Option<&'static str>`
 
@@ -116,17 +51,109 @@ Note: This option is available for Rust 1.7.0 and higher!
 
 Note: This option overrides the original `TS::output_path` logic`!
 
-4) environment variable name  
+4) environment variable name
 
-    #[ts(export_to = env(\"MY_ENV_VAR_PATH\"))] 
+    #[ts(export_to = env(\"MY_ENV_VAR_PATH\"))]
 
 Note: This option is for environment variables defined in the '.cargo/config.toml' file only, accessible through the `env!` macro!
 ";
-        let get_path = |input: ParseStream| -> Result<(syn::Path,Option<LitStr>)>{ 
-            let mut tokens = TokenStream::new();
-            let mut env_var_str = None;
 
-            if input.peek(Token![self])  {
+
+#[derive(Clone, Debug)]
+pub enum CustomPath {
+    Str(String),
+    Static(syn::Path),
+    Fn(syn::Path),
+    Env(syn::LitStr),
+}
+
+type FnOutputPathBody = (TokenStream, Option<TokenStream>);
+
+impl CustomPath {
+    pub fn get_path_and_some_decl(&self, ts_name: &String) -> FnOutputPathBody {
+        match self {
+            Self::Str(input) => Self::str_path(input, ts_name),
+
+            Self::Static(input) => Self::static_path(input, ts_name),
+
+            Self::Fn(input) => Self::fn_path(input, ts_name),
+
+            Self::Env(input) => Self::env_path(input, ts_name),
+        }
+    }
+
+    fn str_path(input: &String, ts_name: &String) -> FnOutputPathBody {
+        let path = if input.ends_with('/') {
+            format!("{}{}.ts", input, ts_name)
+        } else {
+            input.to_owned()
+        };
+
+        return (quote!(#path), None);
+    }
+
+    fn static_path(input: &syn::Path, ts_name: &String) -> FnOutputPathBody {
+        let path_ident = format_ident!("path");
+        let stat_path_ident = format_ident!("PATH");
+        let path_decl = quote! {
+
+            static #stat_path_ident: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+
+            let #path_ident = #stat_path_ident.get_or_init( ||
+                {
+                    if #input.ends_with('/')  {
+                        format!("{}{}.ts", #input, #ts_name)
+                    } else {
+                        format!("{}",#input)
+                    }
+                }
+            );
+        };
+
+        (quote!(#path_ident), Some(path_decl))
+    }
+
+    fn fn_path(input: &syn::Path, ts_name: &String) -> FnOutputPathBody {
+        let path_ident = format_ident!("path");
+
+        // check the type of the function pointer 
+        let path_decl = quote! {
+        let path : fn(&'static str) -> Option<&'static str> = #input;
+        };
+
+        (quote! {#path_ident(#ts_name)?}, Some(path_decl))
+    }
+
+    fn env_path(input: &LitStr, ts_name: &String) -> FnOutputPathBody {
+        let path_ident = format_ident!("path");
+
+        let path_decl = quote! {
+
+            let #path_ident = if std::env!(#input).ends_with('/') {
+                std::concat!(std::env!(#input),#ts_name,".ts")
+            } else {
+                std::env!(#input)
+            };
+        };
+
+        (quote!(#path_ident), Some(path_decl))
+    }
+}
+
+impl Parse for CustomPath {
+    fn parse(input: ParseStream) -> Result<CustomPath> {
+        input.parse::<Token![=]>()?;
+        let span = input.span();
+        let mut some_ident = None;
+
+        let get_path = |pont_ident: Option<Ident>, input: ParseStream| -> Result<syn::Path> {
+            let mut tokens = TokenStream::new();
+
+            if let Some(ident) = pont_ident {
+                tokens.extend(quote!(#ident))
+            }
+
+            if input.peek(Token![self]) {
                 let token = input.parse::<Token![self]>()?;
                 tokens.extend(quote!(#token));
             }
@@ -147,74 +174,74 @@ Note: This option is for environment variables defined in the '.cargo/config.tom
                 let token = input.parse::<Token![::]>()?;
                 tokens.extend(quote!(#token));
 
-                if input.peek(Ident){
+                if input.peek(Ident) {
                     let ident = input.parse::<Ident>()?;
                     tokens.extend(quote!(#ident));
-                } else { return Err(Error::new(input.span(),"expected ident")) }
+                } else {
+                    return Err(Error::new(input.span(), "expected ident"));
+                }
             }
 
-            if input.peek(syn::token::Paren){
-                let content;
-                syn::parenthesized!(content in input);
-                env_var_str = Some(content.parse::<LitStr>()?);
-            }
-
-            Ok((syn::parse2::<syn::Path>(tokens)?,env_var_str))
+            Ok(syn::parse2::<syn::Path>(tokens)?)
         };
 
+        let get_str = |input: ParseStream| -> Result<LitStr> {
+            match Lit::parse(input)? {
+                Lit::Str(string) => Ok(string),
+                _ => Err(Error::new(span, PARSING_ERROR_MSG)),
+            }
+        };
+
+        // reminder
+        if input.peek(Token![?]) {
+            let msg = format!("{PATH_CONVENTION_MSG}\n{PARSING_ERROR_MSG}");
+            return Err(Error::new(span, msg));
+        }
 
         // string literal
-        if input.peek(LitStr){
-            if let Ok(lit) = Lit::parse(input){
-                match lit {
-                    Lit::Str(string) => { return Ok(CustomPath::Str(string.value())); },
-                    _ => { return Err(Error::new(span, msg)); },
-                }
-            } 
-        } 
-
-        match get_path(input) {
-
-            Ok((path,arg)) => {
-    
-                if !path.segments.is_empty(){
-        
-                    if let Some( env_var_str ) = arg {
-            
-                        if path.is_ident("env") {
-                            return Ok(CustomPath::Env(env_var_str));
-                        }
-         
-                    } else {
-        
-                        let last  = &path.segments.last().unwrap().ident;
-        
-                        // static or const 
-                        if is_screaming_snake_case(&last.to_string()) {
-                            return Ok(CustomPath::Static(path));
-                        }
-            
-                        // function 
-                        if is_snake_case(&last.to_string()) {
-                            return Ok(CustomPath::Fn(path));
-                        }    
-                    }
-                }
-                return Err(Error::new(span, msg)); 
-            },
-            
-            Err(e) => return Err(Error::new(e.span(), msg)),
+        if input.peek(LitStr) {
+            return Ok(CustomPath::Str(get_str(input)?.value()));
         }
-    } 
+
+        // environment variable
+        if input.peek(Ident) && input.peek2(syn::token::Paren) && input.peek3(LitStr) {
+            // needs a check for the ident
+            let ident = input.parse::<Ident>()?;
+
+            if ident == "env" {
+                let content;
+                syn::parenthesized!(content in input);
+                let env_str = content.parse::<LitStr>()?;
+                return Ok(CustomPath::Env(env_str));
+            } else {
+                some_ident = Some(ident);
+            }
+        }
+
+        // path  to a const | static | function
+        if let Ok(path) = get_path(some_ident, input) {
+            let last = &path.segments.last().unwrap().ident;
+
+            // const | static
+            if is_screaming_snake_case(&last.to_string()) {
+                return Ok(CustomPath::Static(path));
+            }
+
+            // function
+            if is_snake_case(&last.to_string()) {
+                return Ok(CustomPath::Fn(path));
+            }
+        }
+
+        Err(Error::new(span, PARSING_ERROR_MSG))
+    }
 }
 
-
-// These functions mimic Rust's naming conventions for 
+// These functions mimic Rust's naming conventions for
 // statics, constants, and function .
-// To be replaced with proper, more robust validation. 
+// To be replaced with proper, more robust validation.
 
 fn is_screaming_snake_case(s: &str) -> bool {
-
     if s.is_empty() || s.starts_with('_') || s.ends_with('_') || s.contains("__") {
         return false;
     }
@@ -224,12 +251,10 @@ fn is_screaming_snake_case(s: &str) -> bool {
             return false;
         }
     }
-
     true
 }
 
 fn is_snake_case(s: &str) -> bool {
-
     if s.is_empty() || s.starts_with('_') {
         return false;
     }
@@ -239,6 +264,5 @@ fn is_snake_case(s: &str) -> bool {
             return false;
         }
     }
-
     true
 }

--- a/macros/src/path.rs
+++ b/macros/src/path.rs
@@ -1,0 +1,244 @@
+use quote::{format_ident, quote};
+use proc_macro2::TokenStream;
+use syn::{
+    parse::{Parse, ParseStream},
+    Error, Lit, Ident,LitStr, Token, Result,
+};
+
+
+#[derive(Clone,Debug)]
+pub enum CustomPath{
+    Str(String),
+    Static(syn::Path), 
+    Fn(syn::Path),  
+    Env(syn::LitStr),     
+}
+
+type FnOutputPathBody = ( TokenStream, Option<TokenStream> );
+
+impl CustomPath {
+    
+    pub fn get_path_and_some_decl(&self, ts_name: &String ) -> FnOutputPathBody {
+
+        match self {
+
+            Self::Str(input) => { Self::str_path(input,ts_name) },
+
+            Self::Static(input) => { Self::static_path(input,ts_name) },
+
+            Self::Fn(input) => { Self::fn_path(input,ts_name) },
+
+            Self::Env(input) => { Self::env_path(input,ts_name) },
+
+        } 
+    }
+
+    fn str_path( input: &String, ts_name: &String ) -> FnOutputPathBody {
+
+        let path = 
+        if input.ends_with('/') {
+            format!("{}{}.ts", input, ts_name)
+        }  else {
+            input.to_owned()
+        };
+
+        return (quote!(#path),None);
+    }
+
+    fn static_path( input: &syn::Path, ts_name: &String ) -> FnOutputPathBody {
+
+        let path_ident      = format_ident!("path");
+        let stat_path_ident = format_ident!("PATH");
+        let path_decl = quote! {
+
+            static #stat_path_ident: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+        
+            let #path_ident = #stat_path_ident.get_or_init( ||
+                {
+                    if #input.ends_with('/')  {
+                        format!("{}{}.ts", #input, #ts_name)
+                    } else {
+                        format!("{}",#input)
+                    }
+                } 
+            );
+        };
+
+        ( quote!(#path_ident), Some(path_decl) )
+    }
+
+    fn fn_path( input: &syn::Path, ts_name: &String ) -> FnOutputPathBody { 
+        
+        ( quote!{#input (#ts_name)?}, None)
+    }
+
+    fn env_path( input: &LitStr, ts_name: &String ) -> FnOutputPathBody {
+
+        let path_ident = format_ident!("path");
+
+        let path_decl = quote!{
+
+            let #path_ident = if std::env!(#input).ends_with('/') {
+                std::concat!(std::env!(#input),#ts_name,".ts")
+            } else {
+                std::env!(#input)
+            };
+        };
+
+        ( quote!(#path_ident), Some(path_decl) )
+    }
+
+}
+
+impl Parse for CustomPath {
+
+    fn parse(input: ParseStream) -> Result<CustomPath> {
+        input.parse::<Token![=]>()?;
+        let span = input.span();
+
+        let msg = 
+"expected arguments for 'export_to':
+
+1) string literal 
+    #[ts(export_to = \"my/path\")] 
+
+2) static or constant variable name 
+
+    #[ts(export_to = MY_STATIC_PATH)]
+    #[ts(export_to = crate::MY_STATIC_PATH)]
+
+Note: This option is available for Rust 1.7.0 and higher!
+
+3) function name of a `Fn(&'static str) -> Option<&'static str>`
+
+    #[ts(export_to = get_path)]
+    #[ts(export_to = crate::get_path)]
+
+Note: This option overrides the original `TS::output_path` logic`!
+
+4) environment variable name  
+
+    #[ts(export_to = env(\"MY_ENV_VAR_PATH\"))] 
+
+Note: This option is for environment variables defined in the '.cargo/config.toml' file only, accessible through the `env!` macro!
+";
+        let get_path = |input: ParseStream| -> Result<(syn::Path,Option<LitStr>)>{ 
+            let mut tokens = TokenStream::new();
+            let mut env_var_str = None;
+
+            if input.peek(Token![self])  {
+                let token = input.parse::<Token![self]>()?;
+                tokens.extend(quote!(#token));
+            }
+            if input.peek(Token![super]) {
+                let token = input.parse::<Token![super]>()?;
+                tokens.extend(quote!(#token));
+            }
+            if input.peek(Token![crate]) {
+                let token = input.parse::<Token![crate]>()?;
+                tokens.extend(quote!(#token));
+            }
+            if input.peek(Ident) {
+                let ident = input.parse::<Ident>()?;
+                tokens.extend(quote!(#ident));
+            }
+
+            while input.peek(Token![::]) {
+                let token = input.parse::<Token![::]>()?;
+                tokens.extend(quote!(#token));
+
+                if input.peek(Ident){
+                    let ident = input.parse::<Ident>()?;
+                    tokens.extend(quote!(#ident));
+                } else { return Err(Error::new(input.span(),"expected ident")) }
+            }
+
+            if input.peek(syn::token::Paren){
+                let content;
+                syn::parenthesized!(content in input);
+                env_var_str = Some(content.parse::<LitStr>()?);
+            }
+
+            Ok((syn::parse2::<syn::Path>(tokens)?,env_var_str))
+        };
+
+
+        // string literal
+        if input.peek(LitStr){
+            if let Ok(lit) = Lit::parse(input){
+                match lit {
+                    Lit::Str(string) => { return Ok(CustomPath::Str(string.value())); },
+                    _ => { return Err(Error::new(span, msg)); },
+                }
+            } 
+        } 
+
+        match get_path(input) {
+
+            Ok((path,arg)) => {
+    
+                if !path.segments.is_empty(){
+        
+                    if let Some( env_var_str ) = arg {
+            
+                        if path.is_ident("env") {
+                            return Ok(CustomPath::Env(env_var_str));
+                        }
+         
+                    } else {
+        
+                        let last  = &path.segments.last().unwrap().ident;
+        
+                        // static or const 
+                        if is_screaming_snake_case(&last.to_string()) {
+                            return Ok(CustomPath::Static(path));
+                        }
+            
+                        // function 
+                        if is_snake_case(&last.to_string()) {
+                            return Ok(CustomPath::Fn(path));
+                        }    
+                    }
+                }
+                return Err(Error::new(span, msg)); 
+            },
+            
+            Err(e) => return Err(Error::new(e.span(), msg)),
+        }
+    } 
+}
+
+
+// These functions mimic Rust's naming conventions for 
+// statics, constants, and function .
+// To be replaced with proper, more robust validation. 
+
+fn is_screaming_snake_case(s: &str) -> bool {
+
+    if s.is_empty() || s.starts_with('_') || s.ends_with('_') || s.contains("__") {
+        return false;
+    }
+
+    for c in s.chars() {
+        if !c.is_ascii_uppercase() && c != '_' {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn is_snake_case(s: &str) -> bool {
+
+    if s.is_empty() || s.starts_with('_') {
+        return false;
+    }
+
+    for c in s.chars() {
+        if !c.is_ascii_lowercase() && c != '_' {
+            return false;
+        }
+    }
+
+    true
+}


### PR DESCRIPTION
Hi there,
and thank you for this crate!


In addition to a `'static str` as the argument to `export_to` attribute 
we could use the following types :

- an environment variable defined in `.cargo/config.toml`
```rust
#[ts(export_to = env("CONFIG_ENV_VAR_PATH"))]
```
`TS::output_path` method generated for the type:
```rust
    fn output_path() -> Option<&'static std::path::Path> {
        let path = if std::env!("CONFIG_ENV_VAR_PATH").ends_with('/') {
            std::concat!(std::env!("CONFIG_ENV_VAR_PATH"), "ObjB", ".ts")
        } else {
            std::env!("CONFIG_ENV_VAR_PATH")
        };
        Some(std::path::Path::new(path))
    }

```
- name of a function (`Fn(&'static str) -> Option<&'static str>`) that will override the standard `TS::output_path` method logic. 


example:
```rust

// ts_name is provided by TS macro (name of the ts type)

pub fn get_path_fn(ts_name: &'static str) -> Option<&'static str> {
    match ts_name {
        "ObjA" => Some("../ts-fn-path/ObjA.ts"),
        "ObjB" => Some("../ts-fn-path/B/ObjB.ts"),
        _ => None, 
    }
}
``` 

the argument is an identifier or a path to our function
```rust
#[ts(export_to = get_path_fn)]

#[ts(export_to = crate::get_path_fn)]
```

`TS::output_path` method generated for the ( ts name `ObjB`):
```rust
    fn output_path() -> Option<&'static std::path::Path> {
        Some(std::path::Path::new(crate::get_path_fn("ObjB")?))
    }

```

- For users of Rust 1.7.0 and higher `const` and `static` names 

```rust
static MY_STATIC_PATH: &'static str = "../ts-static-path/";
const MY_CONST_PATH: &'static str   = "../ts-const-path/";
```
 again as  identifier or path

```rust
#[ts(export_to=crate::MY_STATIC_PATH)]
#[ts(export_to=MY_CONST_PATH)]
```

`TS::output_path` method generated for the type:
```rust
    fn output_path() -> Option<&'static std::path::Path> {
        static PATH: std::sync::OnceLock<String> = std::sync::OnceLock::new();
        let path = PATH
            .get_or_init(|| {
                if crate::MY_CONST_PATH.ends_with('/') {
                    format!("{}{}.ts", crate ::MY_CONST_PATH, "ObjA")
                } else {
                    format!("{}", crate ::MY_CONST_PATH)
                }
            });
        Some(std::path::Path::new(path))
    }
```
All options are reactive, modifying the source of argument value
will make `TS` export to the new path without need to recompile.


Thinking about the most efficient or correct way to handle paths can be overwhelming, as there's no universally right way to do it! My proposition is to allow users to manage paths using methods already established by the programming community: constants, statics, and environment variables. Unfortunately, due to Rust's limitations for Derive macros and the 'test' runtime, this is currently restricted to those defined in `.cargo/config.toml`.

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
