### PR TITLE
feat(serde-json-impl): handle bool for serde_json::Value

### DIFF
--- a/ts-rs/src/serde_json.rs
+++ b/ts-rs/src/serde_json.rs
@@ -12,6 +12,7 @@ use super::{impl_primitives, impl_shadow, TS};
 pub enum TsJsonValue {
     Number(i32),
     String(String),
+    Boolean(bool),
     Array(Vec<TsJsonValue>),
     Object(HashMap<String, TsJsonValue>),
 }

--- a/ts-rs/tests/integration/serde_json.rs
+++ b/ts-rs/tests/integration/serde_json.rs
@@ -24,7 +24,7 @@ fn using_serde_json() {
     );
     assert_eq!(
         serde_json::Value::decl(),
-        "type JsonValue = number | string | Array<JsonValue> | { [key in string]?: JsonValue };",
+        "type JsonValue = number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue };",
     );
 
     assert_eq!(
@@ -53,7 +53,7 @@ fn inlined_value() {
     assert_eq!(
         InlinedValue::decl(),
         "type InlinedValue = { \
-            any: number | string | Array<JsonValue> | { [key in string]?: JsonValue }, \
+            any: number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue }, \
          };"
     );
 }


### PR DESCRIPTION
## Goal

- Adds `boolean` to the TS type for `serde_json::Value`

### Notes

- As far as I know, `boolean` is a correct type in JSONs, and is one of the possible variants of `serde_json::Value`, so I think it makes sense to add it to the generated TS type

## Changes

- Added new variant to the enum `TsJsonValue` => `Boolean(bool)` 
- Added `| boolean` in the unit tests for `serde-json-impl` feature

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
