### PR TITLE
Include `null` in `serde_json::Value`

### DIFF
--- a/ts-rs/src/serde_json.rs
+++ b/ts-rs/src/serde_json.rs
@@ -15,6 +15,7 @@ pub enum TsJsonValue {
     Boolean(bool),
     Array(Vec<TsJsonValue>),
     Object(HashMap<String, TsJsonValue>),
+    Null(()),
 }
 
 impl_shadow!(as TsJsonValue: impl TS for serde_json::Value);

--- a/ts-rs/tests/integration/serde_json.rs
+++ b/ts-rs/tests/integration/serde_json.rs
@@ -24,7 +24,7 @@ fn using_serde_json() {
     );
     assert_eq!(
         serde_json::Value::decl(),
-        "type JsonValue = number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue };",
+        "type JsonValue = number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue } | null;",
     );
 
     assert_eq!(
@@ -53,7 +53,7 @@ fn inlined_value() {
     assert_eq!(
         InlinedValue::decl(),
         "type InlinedValue = { \
-            any: number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue }, \
+            any: number | string | boolean | Array<JsonValue> | { [key in string]?: JsonValue } | null, \
          };"
     );
 }


### PR DESCRIPTION
## Goal
`null` was missing from `serde_json::Value`.  
See #358.

## Checklist

- ~~[ ] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)~~.
- ~~[ ] If necessary, I have added documentation related to the changes made.~~
- [x] I have added or updated the tests related to the changes made.
