### PR TITLE
Add `cargo test export_bindings` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ struct User {
     last_name: String,
 }
 ```
-When running `cargo test`, the TypeScript bindings will be exported to the file `bindings/User.ts`.
+When running `cargo test` or `cargo test export_bindings`, the TypeScript bindings will be exported to the file `bindings/User.ts`.
 
 ### Features
 - generate type declarations from rust structs

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -54,7 +54,7 @@
 //!     last_name: String,
 //! }
 //! ```
-//! When running `cargo test`, the TypeScript bindings will be exported to the file `bindings/User.ts`.
+//! When running `cargo test` or `cargo test export_bindings`, the TypeScript bindings will be exported to the file `bindings/User.ts`.
 //!
 //! ## Features
 //! - generate type declarations from rust structs


### PR DESCRIPTION
## Goal

This should be the main way to export bindings, as many projects have tests that can take a long time to run. For our project (lemmy), tests can take over a minute, but our javascript library doesn't actually need to run them, just generate bindings.

Context #166

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
