### PR TITLE
Add `#[ts(optional)]` to struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 ### Breaking
 - Added `OptionInnerType` associated type to the `TS` trait. If you manually implement `TS`, you must set this associated type to `Self` in all of your implementations.
+- Raised MSRV to `1.78.0` due to use of `#[diagnostic::on_unimplemented]` and `let ... else { ... }`
 
 ### Features
 - Added `#[ts(optional_fields)]` and `#[ts(optional_fields = nullable)]` attribute to structs, this attribute is equivalent to using the corresponding `#[ts(optional)]` or `#[ts(optional = nullable)]` on every field of the struct. ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 ### Breaking
 - Change how `HashMap<K, V>` is represented in TypeScript. The resulting bindings (`{ [key in K]?: V }` instead of `{ [key: K]: V }`) are more accurate and flexible.
+- Added `OptionInnerType` associated type to the `TS` trait. If you manually implement `TS`, you must set this associated type to `Self` in all of your implementations.
 
 ### Features
 
@@ -8,12 +9,14 @@
 - The `bson-uuid-impl` feature now supports `bson::oid::ObjectId` as well ([#340](https://github.com/Aleph-Alpha/ts-rs/pull/340))
 - Add support for types from `smol_str` behind cargo feature `smol_str-impl` ([#350](https://github.com/Aleph-Alpha/ts-rs/pull/350))
 - Support `#[ts(as = "...")]` and `#[ts(type = "...")]` on enum variants ([#384](https://github.com/Aleph-Alpha/ts-rs/pull/384))
+- Added `#[ts(optional_fields)]` and `#[ts(optional_fields = nullable)]` attribute to structs, this attribute is equivalent to using the corresponding `#[ts(optional)]` or `#[ts(optional = nullable)]` on every field of the struct. ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
 
 ### Fixes
 
 - Properly handle block doc comments ([#342](https://github.com/Aleph-Alpha/ts-rs/pull/342))
 - Fix error in internally tagged enums with flattened fields ([#344](https://github.com/Aleph-Alpha/ts-rs/pull/344))
 - Always use forward slash on import paths ([#346](https://github.com/Aleph-Alpha/ts-rs/pull/346))
+- Fix `#[ts(optional)]` error when using a type alias for `Option` or fully qqualifying it as `core::option::Option` ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
 
 # 9.0.1
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# master
+### Breaking
+- Added `OptionInnerType` associated type to the `TS` trait. If you manually implement `TS`, you must set this associated type to `Self` in all of your implementations.
+
+### Features
+- Added `#[ts(optional_fields)]` and `#[ts(optional_fields = nullable)]` attribute to structs, this attribute is equivalent to using the corresponding `#[ts(optional)]` or `#[ts(optional = nullable)]` on every field of the struct. ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
+
+### Fixes
+- Fix `#[ts(optional)]` error when using a type alias for `Option` or fully qqualifying it as `core::option::Option` ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
+
 # 10.1.0
 ### Features
 - Add support for synchronization primitives from `tokio` (feature `tokio-impl`)
@@ -8,7 +18,6 @@
 # 10.0.0
 ### Breaking
 - Change how `HashMap<K, V>` is represented in TypeScript. The resulting bindings (`{ [key in K]?: V }` instead of `{ [key: K]: V }`) are more accurate and flexible.
-- Added `OptionInnerType` associated type to the `TS` trait. If you manually implement `TS`, you must set this associated type to `Self` in all of your implementations.
 
 ### Features
 
@@ -16,14 +25,12 @@
 - The `bson-uuid-impl` feature now supports `bson::oid::ObjectId` as well ([#340](https://github.com/Aleph-Alpha/ts-rs/pull/340))
 - Add support for types from `smol_str` behind cargo feature `smol_str-impl` ([#350](https://github.com/Aleph-Alpha/ts-rs/pull/350))
 - Support `#[ts(as = "...")]` and `#[ts(type = "...")]` on enum variants ([#384](https://github.com/Aleph-Alpha/ts-rs/pull/384))
-- Added `#[ts(optional_fields)]` and `#[ts(optional_fields = nullable)]` attribute to structs, this attribute is equivalent to using the corresponding `#[ts(optional)]` or `#[ts(optional = nullable)]` on every field of the struct. ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
 
 ### Fixes
 
 - Properly handle block doc comments ([#342](https://github.com/Aleph-Alpha/ts-rs/pull/342))
 - Fix error in internally tagged enums with flattened fields ([#344](https://github.com/Aleph-Alpha/ts-rs/pull/344))
 - Always use forward slash on import paths ([#346](https://github.com/Aleph-Alpha/ts-rs/pull/346))
-- Fix `#[ts(optional)]` error when using a type alias for `Option` or fully qqualifying it as `core::option::Option` ([#366](https://github.com/Aleph-Alpha/ts-rs/pull/366))
 
 # 9.0.1
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Feel free to open an issue, discuss using GitHub discussions or open a PR.
 [See CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
 
 ### MSRV
-The Minimum Supported Rust Version for this crate is 1.63.0
+The Minimum Supported Rust Version for this crate is 1.78.0
 
 License: MIT

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -55,10 +55,7 @@ impl Attr for FieldAttr {
             rename: self.rename.or(other.rename),
             inline: self.inline || other.inline,
             skip: self.skip || other.skip,
-            optional: Optional {
-                optional: self.optional.optional || other.optional.optional,
-                nullable: self.optional.nullable || other.optional.nullable,
-            },
+            optional: self.optional.or(other.optional),
             flatten: self.flatten || other.flatten,
 
             using_serde_with: self.using_serde_with || other.using_serde_with,
@@ -124,7 +121,7 @@ impl Attr for FieldAttr {
                 );
             }
 
-            if self.optional.optional {
+            if let Optional::Optional { .. } = self.optional {
                 syn_err_spanned!(
                     field;
                     "`optional` is not compatible with `flatten`"
@@ -147,7 +144,7 @@ impl Attr for FieldAttr {
                 );
             }
 
-            if self.optional.optional {
+            if let Optional::Optional { .. } = self.optional {
                 syn_err_spanned!(
                     field;
                     "`optional` cannot with tuple struct fields"

--- a/macros/src/attr/field.rs
+++ b/macros/src/attr/field.rs
@@ -97,6 +97,13 @@ impl Attr for FieldAttr {
                     "`type` is not compatible with `flatten`"
                 );
             }
+
+            if let Optional::Optional { .. } = self.optional {
+                syn_err_spanned!(
+                    field;
+                    "`type` is not compatible with `optional`"
+                );
+            }
         }
 
         if self.flatten {

--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -19,9 +19,28 @@ mod variant;
 /// `#[ts(optional)]` turns an `t: Option<T>` into `t?: T`, while
 /// `#[ts(optional = nullable)]` turns it into `t?: T | null`.
 #[derive(Default, Clone, Copy)]
-pub struct Optional {
-    pub optional: bool,
-    pub nullable: bool,
+pub enum Optional {
+    Optional {
+        nullable: bool,
+    },
+
+    #[default]
+    NotOptional,
+}
+
+impl Optional {
+    pub fn or(self, other: Optional) -> Self {
+        match (self, other) {
+            (Self::NotOptional, Self::NotOptional) => Self::NotOptional,
+
+            (Self::Optional { nullable }, Self::NotOptional)
+            | (Self::NotOptional, Self::Optional { nullable }) => Self::Optional { nullable },
+
+            (Self::Optional { nullable: a }, Self::Optional { nullable: b }) => {
+                Self::Optional { nullable: a || b }
+            }
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -202,8 +221,5 @@ fn parse_optional(input: ParseStream) -> Result<Optional> {
         false
     };
 
-    Ok(Optional {
-        optional: true,
-        nullable,
-    })
+    Ok(Optional::Optional { nullable })
 }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -91,10 +91,7 @@ impl Attr for StructAttr {
                 (Some(bound), None) | (None, Some(bound)) => Some(bound),
                 (None, None) => None,
             },
-            optional: Optional {
-                optional: self.optional.optional || other.optional.optional,
-                nullable: self.optional.nullable || other.optional.nullable,
-            },
+            optional: self.optional.or(other.optional),
         }
     }
 

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -108,6 +108,10 @@ impl Attr for StructAttr {
             if self.tag.is_some() {
                 syn_err!("`tag` is not compatible with `type`");
             }
+
+            if let Optional::Optional { .. } = self.optional_fields {
+                syn_err!("`optional_fields` is not compatible with `type`");
+            }
         }
 
         if self.type_as.is_some() {
@@ -118,6 +122,10 @@ impl Attr for StructAttr {
             if self.rename_all.is_some() {
                 syn_err!("`rename_all` is not compatible with `as`");
             }
+
+            if let Optional::Optional { .. } = self.optional_fields {
+                syn_err!("`optional_fields` is not compatible with `as`");
+            }
         }
 
         if !matches!(item, Fields::Named(_)) {
@@ -127,6 +135,10 @@ impl Attr for StructAttr {
 
             if self.rename_all.is_some() {
                 syn_err!("`rename_all` cannot be used with unit or tuple structs");
+            }
+
+            if let Optional::Optional { .. } = self.optional_fields {
+                syn_err!("`optional_fields` cannot be used with unit or tuple structs");
             }
         }
 

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use syn::{parse_quote, Attribute, Fields, Ident, Path, Result, Type, WherePredicate};
 
 use super::{
-    parse_assign_from_str, parse_assign_inflection, parse_bound, parse_concrete, Attr,
-    ContainerAttr, Serde, Tagged,
+    parse_assign_from_str, parse_assign_inflection, parse_bound, parse_concrete, parse_optional,
+    Attr, ContainerAttr, Optional, Serde, Tagged,
 };
 use crate::{
     attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
@@ -24,6 +24,7 @@ pub struct StructAttr {
     pub docs: String,
     pub concrete: HashMap<Ident, Type>,
     pub bound: Option<Vec<WherePredicate>>,
+    pub optional: Optional,
 }
 
 impl StructAttr {
@@ -90,6 +91,10 @@ impl Attr for StructAttr {
                 (Some(bound), None) | (None, Some(bound)) => Some(bound),
                 (None, None) => None,
             },
+            optional: Optional {
+                optional: self.optional.optional || other.optional.optional,
+                nullable: self.optional.nullable || other.optional.nullable,
+            },
         }
     }
 
@@ -152,6 +157,7 @@ impl_parse! {
         "export_to" => out.export_to = Some(parse_assign_str(input)?),
         "concrete" => out.concrete = parse_concrete(input)?,
         "bound" => out.bound = Some(parse_bound(input)?),
+        "optional" => out.optional = parse_optional(input)?,
     }
 }
 

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -24,7 +24,7 @@ pub struct StructAttr {
     pub docs: String,
     pub concrete: HashMap<Ident, Type>,
     pub bound: Option<Vec<WherePredicate>>,
-    pub optional: Optional,
+    pub optional_fields: Optional,
 }
 
 impl StructAttr {
@@ -91,7 +91,7 @@ impl Attr for StructAttr {
                 (Some(bound), None) | (None, Some(bound)) => Some(bound),
                 (None, None) => None,
             },
-            optional: self.optional.or(other.optional),
+            optional_fields: self.optional_fields.or(other.optional_fields),
         }
     }
 
@@ -154,7 +154,7 @@ impl_parse! {
         "export_to" => out.export_to = Some(parse_assign_str(input)?),
         "concrete" => out.concrete = parse_concrete(input)?,
         "bound" => out.bound = Some(parse_bound(input)?),
-        "optional" => out.optional = parse_optional(input)?,
+        "optional_fields" => out.optional_fields = parse_optional(input)?,
     }
 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -80,6 +80,7 @@ impl DerivedTS {
         quote! {
             #impl_start {
                 #assoc_type
+                type OptionInnerType = Self;
 
                 fn ident() -> String {
                     #ident.to_owned()
@@ -156,6 +157,7 @@ impl DerivedTS {
                 }
                 impl #crate_rename::TS for #generics {
                     type WithoutGenerics = #generics;
+                    type OptionInnerType = Self;
                     fn name() -> String { stringify!(#generics).to_owned() }
                     fn inline() -> String { panic!("{} cannot be inlined", #name) }
                     fn inline_flattened() -> String { stringify!(#generics).to_owned() }

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -24,7 +24,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
     if let Some(attr_type_override) = &enum_attr.type_override {
         return type_override::type_override_enum(&enum_attr, &name, attr_type_override);
     }
- 
+
     if let Some(attr_type_as) = &enum_attr.type_as {
         return type_as::type_as_enum(&enum_attr, &name, attr_type_as);
     }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -144,7 +144,7 @@ fn format_field(
                 if let Optional::Optional { nullable: false } = opt {
                     quote! {
                         if <#ty as #crate_rename::TS>::IS_OPTION {
-                            <#ty as #crate_rename::TS>::option_inner_inline().unwrap()
+                            <#ty as #crate_rename::TS>::name().trim_end_matches(" | null").to_owned()
                         } else {
                             <#ty as #crate_rename::TS>::inline()
                         }
@@ -157,7 +157,7 @@ fn format_field(
                 if let Optional::Optional { nullable: false } = opt {
                     quote! {
                         if <#ty as #crate_rename::TS>::IS_OPTION {
-                            <#ty as #crate_rename::TS>::option_inner_name().unwrap()
+                            <#ty as #crate_rename::TS>::name().trim_end_matches(" | null").to_owned()
                         } else {
                             <#ty as #crate_rename::TS>::name()
                         }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -1,13 +1,13 @@
-use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
-use syn::{parse_quote, Field, FieldsNamed, Path, Result};
-use syn::spanned::Spanned;
 use crate::{
     attr::{Attr, ContainerAttr, FieldAttr, Inflection, Optional, StructAttr},
     deps::Dependencies,
     utils::{raw_name_to_ts_field, to_ts_ident},
     DerivedTS,
 };
+use proc_macro2::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{parse_quote, Field, FieldsNamed, Path, Result};
 
 pub(crate) fn named(attr: &StructAttr, name: &str, fields: &FieldsNamed) -> Result<DerivedTS> {
     let crate_rename = attr.crate_rename();
@@ -31,7 +31,7 @@ pub(crate) fn named(attr: &StructAttr, name: &str, fields: &FieldsNamed) -> Resu
             &mut dependencies,
             field,
             &attr.rename_all,
-            attr.optional,
+            attr.optional_fields,
         )?;
     }
 

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -115,8 +115,17 @@ fn format_field(
             Optional {
                 optional: false, ..
             },
-        )
-        | (
+        ) => match extract_option_argument(&parsed_ty) {
+            Ok(inner_type) => {
+                if nullable {
+                    (&parsed_ty, "?")
+                } else {
+                    (inner_type, "?")
+                }
+            }
+            Err(_) => (&parsed_ty, ""),
+        },
+        (
             _,
             Optional {
                 optional: true,

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -116,18 +116,6 @@ fn format_field(
         quote! { "" }
     };
 
-    let optional_annotation = if let Optional::Optional { .. } = field_attr.optional {
-        quote! {
-            if <#ty as #crate_rename::TS>::IS_OPTION {
-                #optional_annotation
-            } else {
-                panic!("`#[ts(optional)]` can only be used with the Option type")
-            }
-        }
-    } else {
-        optional_annotation
-    };
-
     if field_attr.flatten {
         flattened_fields.push(quote!(<#ty as #crate_rename::TS>::inline_flattened()));
         dependencies.append_from(&ty);

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -15,7 +15,7 @@ categories = [
     "web-programming",
 ]
 readme = "../README.md"
-rust-version = "1.63.0"
+rust-version = "1.78.0"
 
 [features]
 chrono-impl = ["chrono"]

--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -12,6 +12,8 @@ macro_rules! impl_dummy {
     ($($t:ty),*) => {$(
         impl TS for $t {
             type WithoutGenerics = $t;
+            type OptionInnerType = Self;
+
             fn name() -> String { String::new() }
             fn inline() -> String { String::new() }
             fn inline_flattened() -> String { panic!("{} cannot be flattened", Self::name()) }
@@ -26,6 +28,8 @@ impl_dummy!(Utc, Local, FixedOffset);
 
 impl<T: TimeZone + 'static> TS for DateTime<T> {
     type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
     fn ident() -> String {
         "string".to_owned()
     }
@@ -48,6 +52,8 @@ impl<T: TimeZone + 'static> TS for DateTime<T> {
 
 impl<T: TimeZone + 'static> TS for Date<T> {
     type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
     fn ident() -> String {
         "string".to_owned()
     }

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -181,9 +181,9 @@ fn export_and_merge(
     Ok(())
 }
 
-const HEADER_ERROR_MESSAGE: &'static str = "The generated strings must have their NOTE and imports separated from their type declarations by a new line";
+const HEADER_ERROR_MESSAGE: &str = "The generated strings must have their NOTE and imports separated from their type declarations by a new line";
 
-const DECLARATION_START: &'static str = "export type ";
+const DECLARATION_START: &str = "export type ";
 
 /// Inserts the imports and declaration from the newly generated type
 /// into the contents of the file, removimg duplicate imports and organazing

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -47,7 +47,7 @@ mod recursive_export {
         error: Option<ExportError>,
     }
 
-    impl<'a> TypeVisitor for Visit<'a> {
+    impl TypeVisitor for Visit<'_> {
         fn visit<T: TS + 'static + ?Sized>(&mut self) {
             // if an error occurred previously, or the type cannot be exported (it's a primitive),
             // we return

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -122,7 +122,7 @@
 //! [See CONTRIBUTING.md](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md)
 //!
 //! ## MSRV
-//! The Minimum Supported Rust Version for this crate is 1.63.0
+//! The Minimum Supported Rust Version for this crate is 1.78.0
 
 use std::{
     any::TypeId,

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -286,6 +286,12 @@ mod tokio;
 ///   Include the structs name (or value of `#[ts(rename = "..")]`) as a field with the given key.
 ///   <br/><br/>
 ///
+/// - **`#[ts(optional_fields)]`**  
+///   Makes all `Option<T>` fields in a struct optional.
+///   If `#[ts(optional_fields)]` is present, `t?: T` is generated for every `Option<T>` field of the struct.  
+///   If `#[ts(optional_fields = nullable)]` is present, `t?: T | null` is generated for every `Option<T>` field of the struct.  
+///   <br/><br/>
+///
 /// ### struct field attributes
 ///
 /// - **`#[ts(type = "..")]`**  

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -394,6 +394,19 @@ pub trait TS {
     /// automatically read from your doc comments or `#[doc = ".."]` attributes
     const DOCS: Option<&'static str> = None;
 
+    #[doc(hidden)]
+    const IS_OPTION: bool = false;
+
+    #[doc(hidden)]
+    fn option_inner_name() -> Option<String> {
+        None
+    }
+
+    #[doc(hidden)]
+    fn option_inner_inline() -> Option<String> {
+        None
+    }
+
     /// Identifier of this type, excluding generic parameters.
     fn ident() -> String {
         // by default, fall back to `TS::name()`.
@@ -722,6 +735,7 @@ macro_rules! impl_shadow {
 
 impl<T: TS> TS for Option<T> {
     type WithoutGenerics = Self;
+    const IS_OPTION: bool = true;
 
     fn name() -> String {
         format!("{} | null", T::name())
@@ -729,6 +743,14 @@ impl<T: TS> TS for Option<T> {
 
     fn inline() -> String {
         format!("{} | null", T::inline())
+    }
+
+    fn option_inner_name() -> Option<String> {
+        Some(T::name())
+    }
+
+    fn option_inner_inline() -> Option<String> {
+        Some(T::inline())
     }
 
     fn visit_dependencies(v: &mut impl TypeVisitor)

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -465,7 +465,7 @@ pub trait TS {
     {
         let mut deps: Vec<Dependency> = vec![];
         struct Visit<'a>(&'a mut Vec<Dependency>);
-        impl<'a> TypeVisitor for Visit<'a> {
+        impl TypeVisitor for Visit<'_> {
             fn visit<T: TS + 'static + ?Sized>(&mut self) {
                 if let Some(dep) = Dependency::from_ty::<T>() {
                     self.0.push(dep);

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -380,6 +380,7 @@ pub trait TS {
     /// struct GenericType<A, B>(A, B);
     /// impl<A, B> TS for GenericType<A, B> {
     ///     type WithoutGenerics = GenericType<ts_rs::Dummy, ts_rs::Dummy>;
+    ///     type OptionInnerType = Self;
     ///     // ...
     ///     # fn decl() -> String { todo!() }
     ///     # fn decl_concrete() -> String { todo!() }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -397,16 +397,6 @@ pub trait TS {
     #[doc(hidden)]
     const IS_OPTION: bool = false;
 
-    #[doc(hidden)]
-    fn option_inner_name() -> Option<String> {
-        None
-    }
-
-    #[doc(hidden)]
-    fn option_inner_inline() -> Option<String> {
-        None
-    }
-
     /// Identifier of this type, excluding generic parameters.
     fn ident() -> String {
         // by default, fall back to `TS::name()`.
@@ -743,14 +733,6 @@ impl<T: TS> TS for Option<T> {
 
     fn inline() -> String {
         format!("{} | null", T::inline())
-    }
-
-    fn option_inner_name() -> Option<String> {
-        Some(T::name())
-    }
-
-    fn option_inner_inline() -> Option<String> {
-        Some(T::inline())
     }
 
     fn visit_dependencies(v: &mut impl TypeVisitor)

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -631,7 +631,7 @@ impl Dependency {
 #[diagnostic::on_unimplemented(
     message = "`#[ts(optional)]` can only be used on fields of type `Option`",
     note = "`#[ts(optional)]` was used on a field of type {Self}, which is not permitted",
-    label = ""
+    label = "`#[ts(optional)]` is not allowed on field of type {Self}"
 )]
 pub trait IsOption {}
 

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -88,6 +88,9 @@ fn inline() {
     assert_eq!(Inline::inline(), format!("{{ x: {{ {a}, {b}, {c}, }}, }}"));
 }
 
+type Foo = Option<i32>;
+type Bar<T> = Option<T>;
+
 #[derive(TS)]
 #[ts(export, export_to = "optional_field/", optional)]
 struct OptionalStruct {
@@ -97,13 +100,19 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
+    #[ts(optional = nullable)]
     d: i32,
+
+    e: Foo,
+    f: Bar<i32>,
 }
 
 #[test]
 fn struct_optional() {
     assert_eq!(
         OptionalStruct::inline(),
-        format!("{{ a?: number, b?: number, c?: number | null, d: number, }}")
+        format!(
+            "{{ a?: number, b?: number, c?: number | null, d: number, e?: number, f?: number, }}"
+        )
     )
 }

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -87,3 +87,21 @@ fn inline() {
     let c = "c: number | null";
     assert_eq!(Inline::inline(), format!("{{ x: {{ {a}, {b}, {c}, }}, }}"));
 }
+
+#[derive(TS)]
+#[ts(export, export_to = "optional_field/", optional)]
+struct OptionalStruct {
+    a: Option<i32>,
+    b: Option<i32>,
+
+    #[ts(optional = nullable)]
+    c: Option<i32>,
+}
+
+#[test]
+fn struct_optional() {
+    assert_eq!(
+        OptionalStruct::inline(),
+        format!("{{ a?: number, b?: number, c?: number | null, }}")
+    )
+}

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -100,7 +100,6 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
-    #[ts(optional = nullable)]
     d: i32,
 
     e: Foo,

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -96,12 +96,14 @@ struct OptionalStruct {
 
     #[ts(optional = nullable)]
     c: Option<i32>,
+
+    d: i32,
 }
 
 #[test]
 fn struct_optional() {
     assert_eq!(
         OptionalStruct::inline(),
-        format!("{{ a?: number, b?: number, c?: number | null, }}")
+        format!("{{ a?: number, b?: number, c?: number | null, d: number, }}")
     )
 }

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -100,6 +100,8 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
+    // `#[ts(optional)]` on a type that isn't `Option<T>` does nothing
+    #[ts(optional = nullable)]
     d: i32,
 
     e: Foo,

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -100,6 +100,7 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
+    #[ts(optional)]
     d: i32,
 
     e: Foo,

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -92,7 +92,7 @@ type Foo = Option<i32>;
 type Bar<T> = Option<T>;
 
 #[derive(TS)]
-#[ts(export, export_to = "optional_field/", optional)]
+#[ts(export, export_to = "optional_field/", optional_fields)]
 struct OptionalStruct {
     a: Option<i32>,
     b: Option<i32>,

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -100,8 +100,6 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
-    // `#[ts(optional)]` on a type that isn't `Option<T>` does nothing
-    #[ts(optional = nullable)]
     d: i32,
 
     e: Foo,

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -104,6 +104,12 @@ struct OptionalStruct {
 
     e: Foo,
     f: Bar<i32>,
+
+    #[ts(type = "string")]
+    g: Option<i32>,
+
+    #[ts(as = "String")]
+    h: Option<i32>,
 }
 
 #[test]
@@ -111,7 +117,7 @@ fn struct_optional() {
     assert_eq!(
         OptionalStruct::inline(),
         format!(
-            "{{ a?: number, b?: number, c?: number | null, d: number, e?: number, f?: number, }}"
+            "{{ a?: number, b?: number, c?: number | null, d: number, e?: number, f?: number, g: string, h: string, }}"
         )
     )
 }
@@ -129,6 +135,12 @@ struct NullableStruct {
 
     e: Foo,
     f: Bar<i32>,
+
+    #[ts(type = "string")]
+    g: Option<i32>,
+
+    #[ts(as = "String")]
+    h: Option<i32>,
 }
 
 #[test]
@@ -136,7 +148,7 @@ fn struct_nullable() {
     assert_eq!(
         NullableStruct::inline(),
         format!(
-            "{{ a?: number | null, b?: number | null, c?: number | null, d: number, e?: number | null, f?: number | null, }}"
+            "{{ a?: number | null, b?: number | null, c?: number | null, d: number, e?: number | null, f?: number | null, g: string, h: string, }}"
         )
     )
 }

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -115,3 +115,28 @@ fn struct_optional() {
         )
     )
 }
+
+#[derive(TS)]
+#[ts(export, export_to = "optional_field/", optional_fields = nullable)]
+struct NullableStruct {
+    a: Option<i32>,
+    b: Option<i32>,
+
+    #[ts(optional = nullable)]
+    c: Option<i32>,
+
+    d: i32,
+
+    e: Foo,
+    f: Bar<i32>,
+}
+
+#[test]
+fn struct_nullable() {
+    assert_eq!(
+        NullableStruct::inline(),
+        format!(
+            "{{ a?: number | null, b?: number | null, c?: number | null, d: number, e?: number | null, f?: number | null, }}"
+        )
+    )
+}

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -100,7 +100,6 @@ struct OptionalStruct {
     #[ts(optional = nullable)]
     c: Option<i32>,
 
-    #[ts(optional)]
     d: i32,
 
     e: Foo,


### PR DESCRIPTION
## Goal

Allow the use of `#[ts(optional)]` on struct definitions
Closes #364

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
