### PR TITLE
compile-time checked `#[ts(optional)]`

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -80,6 +80,7 @@ impl DerivedTS {
         quote! {
             #impl_start {
                 #assoc_type
+                type OptionInnerType = Self;
 
                 fn ident() -> String {
                     #ident.to_owned()
@@ -156,6 +157,7 @@ impl DerivedTS {
                 }
                 impl #crate_rename::TS for #generics {
                     type WithoutGenerics = #generics;
+                    type OptionInnerType = Self;
                     fn name() -> String { stringify!(#generics).to_owned() }
                     fn inline() -> String { panic!("{} cannot be inlined", #name) }
                     fn inline_flattened() -> String { stringify!(#generics).to_owned() }

--- a/macros/src/types/enum.rs
+++ b/macros/src/types/enum.rs
@@ -24,7 +24,7 @@ pub(crate) fn r#enum_def(s: &ItemEnum) -> syn::Result<DerivedTS> {
     if let Some(attr_type_override) = &enum_attr.type_override {
         return type_override::type_override_enum(&enum_attr, &name, attr_type_override);
     }
- 
+
     if let Some(attr_type_as) = &enum_attr.type_as {
         return type_as::type_as_enum(&enum_attr, &name, attr_type_as);
     }

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -111,7 +111,7 @@ fn format_field(
             quote! {{
                 use std::marker::PhantomData;
                 let actual: PhantomData<#ty> = PhantomData;
-                let must: PhantomData<Option<_>> = actual;
+                let must: PhantomData<std::option::Option<_>> = actual;
                 "?"
             }},
             nullable,

--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -12,6 +12,8 @@ macro_rules! impl_dummy {
     ($($t:ty),*) => {$(
         impl TS for $t {
             type WithoutGenerics = $t;
+            type OptionInnerType = Self;
+
             fn name() -> String { String::new() }
             fn inline() -> String { String::new() }
             fn inline_flattened() -> String { panic!("{} cannot be flattened", Self::name()) }
@@ -26,6 +28,8 @@ impl_dummy!(Utc, Local, FixedOffset);
 
 impl<T: TimeZone + 'static> TS for DateTime<T> {
     type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
     fn ident() -> String {
         "string".to_owned()
     }
@@ -48,6 +52,8 @@ impl<T: TimeZone + 'static> TS for DateTime<T> {
 
 impl<T: TimeZone + 'static> TS for Date<T> {
     type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
     fn ident() -> String {
         "string".to_owned()
     }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -626,6 +626,16 @@ impl Dependency {
     }
 }
 
+#[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "`#[ts(optional)]` can only be used on fields of type `Option`",
+    note = "`#[ts(optional)]` was used on a field of type {Self}, which is not permitted",
+    label = ""
+)]
+pub trait IsOption {}
+
+impl<T> IsOption for Option<T> {}
+
 // generate impls for primitive types
 macro_rules! impl_primitives {
     ($($($ty:ty),* => $l:literal),*) => { $($(

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -390,6 +390,10 @@ pub trait TS {
     /// ```
     type WithoutGenerics: TS + ?Sized;
 
+    /// If the implementing type is `std::option::Option<T>`, then this associated type is set to `T`.
+    /// All other implementations of `TS` should set this type to `Self` instead.
+    type OptionInnerType: ?Sized;
+
     /// JSDoc comment to describe this type in TypeScript - when `TS` is derived, docs are
     /// automatically read from your doc comments or `#[doc = ".."]` attributes
     const DOCS: Option<&'static str> = None;
@@ -627,6 +631,7 @@ macro_rules! impl_primitives {
     ($($($ty:ty),* => $l:literal),*) => { $($(
         impl TS for $ty {
             type WithoutGenerics = Self;
+            type OptionInnerType = Self;
             fn name() -> String { $l.to_owned() }
             fn inline() -> String { <Self as $crate::TS>::name() }
             fn inline_flattened() -> String { panic!("{} cannot be flattened", <Self as $crate::TS>::name()) }
@@ -640,6 +645,7 @@ macro_rules! impl_tuples {
     ( impl $($i:ident),* ) => {
         impl<$($i: TS),*> TS for ($($i,)*) {
             type WithoutGenerics = (Dummy, );
+            type OptionInnerType = Self;
             fn name() -> String {
                 format!("[{}]", [$(<$i as $crate::TS>::name()),*].join(", "))
             }
@@ -672,6 +678,7 @@ macro_rules! impl_wrapper {
     ($($t:tt)*) => {
         $($t)* {
             type WithoutGenerics = Self;
+            type OptionInnerType = Self;
             fn name() -> String { T::name() }
             fn inline() -> String { T::inline() }
             fn inline_flattened() -> String { T::inline_flattened() }
@@ -700,6 +707,7 @@ macro_rules! impl_shadow {
     (as $s:ty: $($impl:tt)*) => {
         $($impl)* {
             type WithoutGenerics = <$s as $crate::TS>::WithoutGenerics;
+            type OptionInnerType = <$s as $crate::TS>::OptionInnerType;
             fn ident() -> String { <$s as $crate::TS>::ident() }
             fn name() -> String { <$s as $crate::TS>::name() }
             fn inline() -> String { <$s as $crate::TS>::inline() }
@@ -725,6 +733,7 @@ macro_rules! impl_shadow {
 
 impl<T: TS> TS for Option<T> {
     type WithoutGenerics = Self;
+    type OptionInnerType = T;
     const IS_OPTION: bool = true;
 
     fn name() -> String {
@@ -765,6 +774,7 @@ impl<T: TS> TS for Option<T> {
 
 impl<T: TS, E: TS> TS for Result<T, E> {
     type WithoutGenerics = Result<Dummy, Dummy>;
+    type OptionInnerType = Self;
 
     fn name() -> String {
         format!("{{ Ok : {} }} | {{ Err : {} }}", T::name(), E::name())
@@ -807,6 +817,7 @@ impl<T: TS, E: TS> TS for Result<T, E> {
 
 impl<T: TS> TS for Vec<T> {
     type WithoutGenerics = Vec<Dummy>;
+    type OptionInnerType = Self;
 
     fn ident() -> String {
         "Array".to_owned()
@@ -852,6 +863,8 @@ impl<T: TS> TS for Vec<T> {
 const ARRAY_TUPLE_LIMIT: usize = 64;
 impl<T: TS, const N: usize> TS for [T; N] {
     type WithoutGenerics = [Dummy; N];
+    type OptionInnerType = Self;
+
     fn name() -> String {
         if N > ARRAY_TUPLE_LIMIT {
             return Vec::<T>::name();
@@ -904,6 +917,7 @@ impl<T: TS, const N: usize> TS for [T; N] {
 
 impl<K: TS, V: TS, H> TS for HashMap<K, V, H> {
     type WithoutGenerics = HashMap<Dummy, Dummy>;
+    type OptionInnerType = Self;
 
     fn ident() -> String {
         panic!()
@@ -950,6 +964,8 @@ impl<K: TS, V: TS, H> TS for HashMap<K, V, H> {
 
 impl<I: TS> TS for Range<I> {
     type WithoutGenerics = Range<Dummy>;
+    type OptionInnerType = Self;
+
     fn name() -> String {
         format!("{{ start: {}, end: {}, }}", I::name(), I::name())
     }
@@ -1082,6 +1098,8 @@ impl std::fmt::Display for Dummy {
 
 impl TS for Dummy {
     type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+
     fn name() -> String {
         "Dummy".to_owned()
     }


### PR DESCRIPTION
Builds on top of #366.

- Get's rid of all string/path manipulation in the macro
  - As a consequence, it's impossible to break this with type aliases in all cases. 
- Produces a compile-time error when `#[ts(optional)]` is used on a non-`Option` field. The error is not great yet - it's probably possible to improve this though.
```rust
    #[ts(optional = nullable)]
    d: i32,
```
```
error[E0308]: mismatched types
  --> ts-rs/tests/integration/optional_field.rs:94:10
   |
94 | #[derive(TS)]
   |          ^^
   |          |
   |          expected `PhantomData<Option<_>>`, found `PhantomData<i32>`
   |          expected due to this
   |
   = note: expected struct `PhantomData<std::option::Option<_>>`
              found struct `PhantomData<i32>`

```
