### PR TITLE
Fix typo in `#[ts(rename_all_fields)]`

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -343,7 +343,7 @@ mod tokio;
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 ///
-/// - **`#[ts(rename_all_fieds = "..")]`**  
+/// - **`#[ts(rename_all_fields = "..")]`**  
 ///   Renames the fields of all the struct variants of this enum. This is equivalent to using
 ///   `#[ts(rename_all = "..")]` on all of the enum's variants.
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"


### PR DESCRIPTION
## Goal

Fix a small typo in the docs
Instead of `#[ts(rename_all_fieds)]` it should be `#[ts(rename_all_fields)]`

## Changes

Fixed the typo

## Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [X] I have added or updated the tests related to the changes made.
