### PR TITLE
Fix `#[ts(as = "...")]` dependency list

### DIFF
--- a/macros/src/types/type_as.rs
+++ b/macros/src/types/type_as.rs
@@ -10,12 +10,15 @@ use crate::{
 pub(crate) fn type_as_struct(attr: &StructAttr, name: &str, type_as: &Type) -> Result<DerivedTS> {
     let crate_rename = attr.crate_rename();
 
+    let mut dependencies = Dependencies::new(crate_rename.clone());
+    dependencies.append_from(type_as);
+
     Ok(DerivedTS {
-        crate_rename: crate_rename.clone(),
+        crate_rename,
         inline: quote!(#type_as::inline()),
         inline_flattened: None,
         docs: attr.docs.clone(),
-        dependencies: Dependencies::new(crate_rename),
+        dependencies,
         export: attr.export,
         export_to: attr.export_to.clone(),
         ts_name: name.to_owned(),
@@ -27,12 +30,15 @@ pub(crate) fn type_as_struct(attr: &StructAttr, name: &str, type_as: &Type) -> R
 pub(crate) fn type_as_enum(attr: &EnumAttr, name: &str, type_as: &Type) -> Result<DerivedTS> {
     let crate_rename = attr.crate_rename();
 
+    let mut dependencies = Dependencies::new(crate_rename.clone());
+    dependencies.append_from(type_as);
+
     Ok(DerivedTS {
-        crate_rename: crate_rename.clone(),
+        crate_rename,
         inline: quote!(#type_as::inline()),
         inline_flattened: None,
         docs: attr.docs.clone(),
-        dependencies: Dependencies::new(crate_rename),
+        dependencies,
         export: attr.export,
         export_to: attr.export_to.clone(),
         ts_name: name.to_owned(),

--- a/ts-rs/tests/integration/top_level_type_as.rs
+++ b/ts-rs/tests/integration/top_level_type_as.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "serde-json-impl")]
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 use ts_rs::TS;
 
 #[derive(TS)]
@@ -20,3 +23,32 @@ pub struct Wrapper<T: TS>(T);
 pub fn top_level_type_as_struct() {
     assert_eq!(Wrapper::<String>::inline(), r#"string"#)
 }
+
+#[cfg(feature = "serde-json-impl")]
+#[derive(TS)]
+#[ts(
+    export,
+    export_to = "top_level_type_as/",
+    as = "HashMap::<String, JsonValue>"
+)]
+pub struct JsonMap(JsonValue);
+
+#[derive(TS)]
+#[ts(export, export_to = "top_level_type_as/")]
+pub struct Foo {
+    x: i32,
+}
+
+#[derive(TS)]
+#[ts(export, export_to = "top_level_type_as/")]
+pub struct Bar {
+    foo: Foo,
+}
+
+#[derive(TS)]
+#[ts(
+    export,
+    export_to = "top_level_type_as/",
+    as = "HashMap::<String, Bar>"
+)]
+pub struct Biz(String);


### PR DESCRIPTION
## Goal

Using `#[ts(as = "...")]` at the top level of a struct would not correctly add the imports to the generated file
Closes #384

## Changes

Add `type_as` to `dependencies`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
