### PR TITLE
Prevent naming collisions with <T as crate::TS>

### DIFF
--- a/macros/src/types/type_as.rs
+++ b/macros/src/types/type_as.rs
@@ -14,8 +14,8 @@ pub(crate) fn type_as_struct(attr: &StructAttr, name: &str, type_as: &Type) -> R
     dependencies.append_from(type_as);
 
     Ok(DerivedTS {
-        crate_rename,
-        inline: quote!(#type_as::inline()),
+        crate_rename: crate_rename.clone(),
+        inline: quote!(<#type_as as #crate_rename::TS>::inline()),
         inline_flattened: None,
         docs: attr.docs.clone(),
         dependencies,
@@ -34,8 +34,8 @@ pub(crate) fn type_as_enum(attr: &EnumAttr, name: &str, type_as: &Type) -> Resul
     dependencies.append_from(type_as);
 
     Ok(DerivedTS {
-        crate_rename,
-        inline: quote!(#type_as::inline()),
+        crate_rename: crate_rename.clone(),
+        inline: quote!(<#type_as as #crate_rename::TS>::inline()),
         inline_flattened: None,
         docs: attr.docs.clone(),
         dependencies,

--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -16,9 +16,9 @@ macro_rules! impl_dummy {
 
             fn name() -> String { String::new() }
             fn inline() -> String { String::new() }
-            fn inline_flattened() -> String { panic!("{} cannot be flattened", Self::name()) }
-            fn decl() -> String { panic!("{} cannot be declared", Self::name()) }
-            fn decl_concrete() -> String { panic!("{} cannot be declared", Self::name()) }
+            fn inline_flattened() -> String { panic!("{} cannot be flattened", <Self as $crate::TS>::name()) }
+            fn decl() -> String { panic!("{} cannot be declared", <Self as $crate::TS>::name()) }
+            fn decl_concrete() -> String { panic!("{} cannot be declared", <Self as $crate::TS>::name()) }
         }
     )*};
 }
@@ -40,13 +40,13 @@ impl<T: TimeZone + 'static> TS for DateTime<T> {
         "string".to_owned()
     }
     fn inline_flattened() -> String {
-        panic!("{} cannot be flattened", Self::name())
+        panic!("{} cannot be flattened", <Self as crate::TS>::name())
     }
     fn decl() -> String {
-        panic!("{} cannot be declared", Self::name())
+        panic!("{} cannot be declared", <Self as crate::TS>::name())
     }
     fn decl_concrete() -> String {
-        panic!("{} cannot be declared", Self::name())
+        panic!("{} cannot be declared", <Self as crate::TS>::name())
     }
 }
 
@@ -64,12 +64,12 @@ impl<T: TimeZone + 'static> TS for Date<T> {
         "string".to_owned()
     }
     fn inline_flattened() -> String {
-        panic!("{} cannot be flattened", Self::name())
+        panic!("{} cannot be flattened", <Self as crate::TS>::name())
     }
     fn decl() -> String {
-        panic!("{} cannot be declared", Self::name())
+        panic!("{} cannot be declared", <Self as crate::TS>::name())
     }
     fn decl_concrete() -> String {
-        panic!("{} cannot be declared", Self::name())
+        panic!("{} cannot be declared", <Self as crate::TS>::name())
     }
 }


### PR DESCRIPTION
## Goal

While writing #385 I noticed the implementation of `TS` for `HashMap` lacked the use of `<T as crate::TS>` in `TS` method calls, which could lead to naming collisions if the user implements some other trait with methods called `name`, `ident` etc, so I took some time to add the trait specifier to every method call I could find. I am not sure I got them all, but I think it should be enough to prevent any issues