### PR TITLE
Handle serde fail gracefully

### DIFF
--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -257,7 +257,7 @@ pub(crate) mod warning {
     }
 }
 #[cfg(not(feature = "serde-compat"))]
-mod warning {
+pub(crate) mod warning {
     use std::fmt::Display;
 
     // Just a stub!

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -76,13 +76,13 @@ macro_rules! impl_parse {
                     match &*key.to_string() {
                         $($k => $e,)*
                         #[allow(unreachable_patterns)]
-                        x => {
+                        _ => {
                             let tokens = crate::attr::skip_until_next_comma($input);
 
                             #[cfg(not(feature = "no-serde-warnings"))]
                             crate::utils::warning::print_warning(
                                 "failed to parse serde attribute",
-                                format!("{x} {tokens}"),
+                                format!("{} {tokens}", key.to_string()),
                                 "ts-rs failed to parse this attribute. It will be ignored.",
                             )
                             .unwrap();

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -76,16 +76,17 @@ macro_rules! impl_parse {
                     match &*key.to_string() {
                         $($k => $e,)*
                         #[allow(unreachable_patterns)]
-                        _ => {
-                            let tokens = crate::attr::skip_until_next_comma($input);
+                        x => {
+                            if cfg!(not(feature = "no-serde-warnings")) {
+                                let tokens = crate::attr::skip_until_next_comma($input);
 
-                            #[cfg(not(feature = "no-serde-warnings"))]
-                            crate::utils::warning::print_warning(
-                                "failed to parse serde attribute",
-                                format!("{} {tokens}", key.to_string()),
-                                "ts-rs failed to parse this attribute. It will be ignored.",
-                            )
-                            .unwrap();
+                                crate::utils::warning::print_warning(
+                                    "failed to parse serde attribute",
+                                    format!("{x} {tokens}"),
+                                    "ts-rs failed to parse this attribute. It will be ignored.",
+                                )
+                                .unwrap();
+                            }
                         }
                     }
 

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -86,6 +86,8 @@ macro_rules! impl_parse {
                                     "ts-rs failed to parse this attribute. It will be ignored.",
                                 )
                                 .unwrap();
+                            } else {
+                                crate::attr::skip_until_next_comma($input);
                             }
                         }
                     }

--- a/ts-rs/tests/integration/field_rename.rs
+++ b/ts-rs/tests/integration/field_rename.rs
@@ -3,13 +3,22 @@
 use ts_rs::TS;
 
 #[derive(TS)]
+#[cfg_attr(feature = "serde-compat", derive(serde::Serialize, serde::Deserialize))]
 struct Rename {
-    a: i32,
+    #[cfg_attr(
+        feature = "serde-compat",
+        serde(rename = "c", skip_serializing_if = "String::is_empty")
+    )]
+    a: String,
     #[ts(rename = "bb")]
     b: i32,
 }
 
 #[test]
 fn test() {
-    assert_eq!(Rename::inline(), "{ a: number, bb: number, }")
+    if (cfg!(feature = "serde-compat")) {
+        assert_eq!(Rename::inline(), "{ c: string, bb: number, }")
+    } else {
+        assert_eq!(Rename::inline(), "{ a: string, bb: number, }")
+    }
 }


### PR DESCRIPTION
## Goal

Prevent `serde` attribute from being ignored when it contains unsupported settings
Closes #388

## Changes

- Split `impl_parse` into two branches to handle `Serde<T>` separately
- Move error reporting from `parse_serde_attrs` to `impl_parse`
- When an unsupported setting is found, skip until the next comma in the attribute

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
