### PR TITLE
Add exporting to native typescript enums with string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export type User = { user_id: number, first_name: string, last_name: string, };
 
 ### Features
 - generate type declarations from rust structs
-- generate union declarations from rust enums
+- generate union declarations (and native typescript enums) from rust enums
 - inline types
 - flatten structs/types
 - generate necessary imports when exporting to multiple files

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -72,6 +72,7 @@ pub(crate) fn named(attr: &StructAttr, ts_name: Expr, fields: &FieldsNamed) -> R
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }
 

--- a/macros/src/types/newtype.rs
+++ b/macros/src/types/newtype.rs
@@ -50,5 +50,6 @@ pub(crate) fn newtype(
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }

--- a/macros/src/types/tuple.rs
+++ b/macros/src/types/tuple.rs
@@ -39,6 +39,7 @@ pub(crate) fn tuple(attr: &StructAttr, ts_name: Expr, fields: &FieldsUnnamed) ->
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }
 

--- a/macros/src/types/type_as.rs
+++ b/macros/src/types/type_as.rs
@@ -28,6 +28,7 @@ pub(crate) fn type_as_struct(
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }
 
@@ -48,5 +49,6 @@ pub(crate) fn type_as_enum(attr: &EnumAttr, ts_name: Expr, type_as: &Type) -> Re
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }

--- a/macros/src/types/type_override.rs
+++ b/macros/src/types/type_override.rs
@@ -25,6 +25,7 @@ pub(crate) fn type_override_struct(
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }
 
@@ -46,5 +47,6 @@ pub(crate) fn type_override_enum(
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     })
 }

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -21,6 +21,7 @@ pub(crate) fn empty_object(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     }
 }
 
@@ -38,6 +39,7 @@ pub(crate) fn empty_array(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     }
 }
 
@@ -55,5 +57,6 @@ pub(crate) fn null(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
         ts_name,
         concrete: attr.concrete.clone(),
         bound: attr.bound.clone(),
+        is_ts_enum: false,
     }
 }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! ## Features
 //! - generate type declarations from rust structs
-//! - generate union declarations from rust enums
+//! - generate union declarations (and native typescript enums) from rust enums
 //! - inline types
 //! - flatten structs/types
 //! - generate necessary imports when exporting to multiple files
@@ -364,6 +364,11 @@ mod tokio;
 ///   Valid values are `lowercase`, `UPPERCASE`, `camelCase`, `snake_case`, `PascalCase`, `SCREAMING_SNAKE_CASE`, "kebab-case" and "SCREAMING-KEBAB-CASE"
 ///   <br/><br/>
 ///  
+/// - **`#[ts(use_ts_enum)]`**  
+///   Exports a typescript enum with string values instead of a union type.
+///   Typescript enums have simple names and values; and therefore cannot be used with `tag`, `type_override`, `type_as`, or kebab-case renaming on the same enum.
+///   <br/><br/>
+///
 /// ### enum variant attributes
 ///
 /// - **`#[ts(rename = "..")]`**  

--- a/ts-rs/tests/integration/enum_typescript.rs
+++ b/ts-rs/tests/integration/enum_typescript.rs
@@ -1,0 +1,99 @@
+#![allow(dead_code)]
+
+#[cfg(feature = "serde-compat")]
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(TS)]
+#[ts(export, export_to = "enum_typescript/", use_ts_enum)]
+#[cfg_attr(feature = "serde-compat", derive(Serialize))]
+#[cfg_attr(feature = "serde-compat", serde(rename_all = "camelCase"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "camelCase"))]
+enum A {
+    MessageOne,
+    MessageTwo,
+}
+
+#[test]
+fn test_use_typescript_enum() {
+    // Let inline funcs still return the normal unions,
+    // so as to not break other types that might inline an enum in their definitions
+    assert_eq!(
+        A::inline_flattened(),
+        r#"("messageOne" | "messageTwo")"#,
+    );
+    assert_eq!(
+        A::inline(),
+        r#"("messageOne" | "messageTwo")"#,
+    );
+    // The decl function return the proper typescript enum
+    assert_eq!(
+        A::decl(),
+        r#"enum A { messageOne = "messageOne", messageTwo = "messageTwo" }"#,
+    );
+    assert_eq!(
+        A::decl_concrete(),
+        r#"enum A { messageOne = "messageOne", messageTwo = "messageTwo" }"#,
+    );
+}
+
+#[derive(TS)]
+#[ts(export, export_to = "enum_typescript/", use_ts_enum)]
+#[cfg_attr(feature = "serde-compat", derive(Serialize))]
+#[cfg_attr(feature = "serde-compat", serde(rename_all = "snake_case"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "snake_case"))]
+enum B {
+    MessageOne,
+    MessageTwo,
+}
+
+#[test]
+fn test_use_typescript_enum_snake_case() {
+    assert_eq!(
+        B::inline_flattened(),
+        r#"("message_one" | "message_two")"#,
+    );
+    assert_eq!(
+        B::inline(),
+        r#"("message_one" | "message_two")"#,
+    );
+    assert_eq!(
+        B::decl(),
+        r#"enum B { message_one = "message_one", message_two = "message_two" }"#,
+    );
+    assert_eq!(
+        B::decl_concrete(),
+        r#"enum B { message_one = "message_one", message_two = "message_two" }"#,
+    );
+}
+
+#[derive(TS)]
+#[ts(export, export_to = "enum_typescript/")]
+#[cfg_attr(feature = "serde-compat", derive(Serialize))]
+#[cfg_attr(feature = "serde-compat", serde(rename_all = "camelCase"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "camelCase"))]
+struct Hello {
+    hello_there: A,
+    #[ts(inline)]
+    good_night: B,
+}
+
+#[test]
+fn test_use_typescript_enum_within_struct() {
+    assert_eq!(
+        Hello::inline_flattened(),
+        r#"{ helloThere: A, goodNight: ("message_one" | "message_two"), }"#,
+    );
+    assert_eq!(
+        Hello::inline(),
+        r#"{ helloThere: A, goodNight: ("message_one" | "message_two"), }"#,
+    );
+    assert_eq!(
+        Hello::decl(),
+        r#"type Hello = { helloThere: A, goodNight: ("message_one" | "message_two"), };"#,
+    );
+    assert_eq!(
+        Hello::decl_concrete(),
+        r#"type Hello = { helloThere: A, goodNight: ("message_one" | "message_two"), };"#,
+    );
+}

--- a/ts-rs/tests/integration/enum_typescript.rs
+++ b/ts-rs/tests/integration/enum_typescript.rs
@@ -97,3 +97,37 @@ fn test_use_typescript_enum_within_struct() {
         r#"type Hello = { helloThere: A, goodNight: ("message_one" | "message_two"), };"#,
     );
 }
+
+#[derive(TS)]
+#[ts(export, export_to = "enum_typescript/", use_ts_enum)]
+#[cfg_attr(feature = "serde-compat", derive(Serialize))]
+#[cfg_attr(feature = "serde-compat", serde(rename_all = "PascalCase"))]
+#[cfg_attr(not(feature = "serde-compat"), ts(rename_all = "PascalCase"))]
+enum C {
+    MessageOne,
+    #[serde(rename = "boo_yah")]
+    MessageTwo,
+}
+
+#[test]
+fn test_use_typescript_enum_with_rename_variant() {
+    // Let inline funcs still return the normal unions,
+    // so as to not break other types that might inline an enum in their definitions
+    assert_eq!(
+        C::inline_flattened(),
+        r#"("MessageOne" | "boo_yah")"#,
+    );
+    assert_eq!(
+        C::inline(),
+        r#"("MessageOne" | "boo_yah")"#,
+    );
+    // The decl function return the proper typescript enum
+    assert_eq!(
+        C::decl(),
+        r#"enum C { MessageOne = "MessageOne", boo_yah = "boo_yah" }"#,
+    );
+    assert_eq!(
+        C::decl_concrete(),
+        r#"enum C { MessageOne = "MessageOne", boo_yah = "boo_yah" }"#,
+    );
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -72,3 +72,4 @@ mod union_with_data;
 mod union_with_internal_tag;
 mod unit;
 mod r#unsized;
+mod enum_typescript;


### PR DESCRIPTION
## Goal

Add native typescript enums with string values. Integer values are not supported.
I have been using this in a very large codebase with many enum types (simple enums, tuple children, struct children, etc) for a few months with no problems. I've decided to open this PR and bring it to the world.


## Changes

I added the attribute `#[ts(use_ts_enum)]` in order to turn a simple rust enum into a typescript enum. Case renaming still works except kebab renaming, because the name of the enum variant must be a valid typescript identifier. Proper warnings and errors are issued if invalid attributes are used alongside `use_ts_enum` on the same enum.
Inlining an enum in a struct switches back to using union types.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
