### PR TITLE
Make `rename_all` compatible with tuple and unit structs as a no-op attribute

### DIFF
--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -132,10 +132,6 @@ impl Attr for StructAttr {
             if self.tag.is_some() {
                 syn_err!("`tag` cannot be used with unit or tuple structs");
             }
-
-            if self.rename_all.is_some() {
-                syn_err!("`rename_all` cannot be used with unit or tuple structs");
-            }
         }
 
         Ok(())

--- a/ts-rs/tests/integration/tuple.rs
+++ b/ts-rs/tests/integration/tuple.rs
@@ -24,7 +24,7 @@ fn test_newtype() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tuple/")]
+#[ts(export, export_to = "tuple/", rename_all = "camelCase")] // rename_all should compile, but it's a noop
 struct TupleNewType(String, i32, (i32, i32));
 
 #[test]
@@ -36,7 +36,7 @@ fn test_tuple_newtype() {
 }
 
 #[derive(TS)]
-#[ts(export, export_to = "tuple/")]
+#[ts(export, export_to = "tuple/", rename_all = "kebab-case")]
 struct Dep1;
 
 #[derive(TS)]


### PR DESCRIPTION
## Goal

Make `#[ts(rename_all = "...")]` compatible with tuple and unit structs and make it a no-op in such cases. This behavior matches how `serde` works by not causing a compiler error, and just not doing anything instead.
Closes #421

## Changes

Removed a check from `StructAttr::assert_validity`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
