### PR TITLE
Change empty object to emit `Record<symbol, never>`

### DIFF
--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -12,7 +12,7 @@ pub(crate) fn empty_object(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
 
     DerivedTS {
         crate_rename: crate_rename.clone(),
-        inline: quote!("Record<never, never>".to_owned()),
+        inline: quote!("Record<symbol, never>".to_owned()),
         inline_flattened: None,
         docs: attr.docs.clone(),
         dependencies: Dependencies::new(crate_rename),

--- a/ts-rs/tests/integration/docs.rs
+++ b/ts-rs/tests/integration/docs.rs
@@ -220,7 +220,7 @@ fn export_c() {
             " *\n",
             " * Testing\n",
             " */\n",
-            "export type C = Record<never, never>;\n",
+            "export type C = Record<symbol, never>;\n",
         )
     } else {
         concat!(
@@ -231,7 +231,7 @@ fn export_c() {
             " *\n",
             " * Testing\n",
             " */\n",
-            "export type C = Record<never, never>;",
+            "export type C = Record<symbol, never>;",
             "\n",
         )
     };

--- a/ts-rs/tests/integration/unit.rs
+++ b/ts-rs/tests/integration/unit.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 struct Unit;
 
 // serde_json serializes this to `{}`.
-// The TS type best describing an empty object is `Record<never, never>`.
+// The TS type best describing an empty object is `Record<symbol, never>`.
 #[derive(TS)]
 #[ts(export, export_to = "unit/")]
 struct Unit2 {}
@@ -25,7 +25,7 @@ struct Unit4(());
 #[test]
 fn test() {
     assert_eq!("type Unit = null;", Unit::decl());
-    assert_eq!("type Unit2 = Record<never, never>;", Unit2::decl());
+    assert_eq!("type Unit2 = Record<symbol, never>;", Unit2::decl());
     assert_eq!("type Unit3 = never[];", Unit3::decl());
     assert_eq!("type Unit4 = null;", Unit4::decl());
 }


### PR DESCRIPTION
## Goal

Fix bad TypeScript inference when combining a tagged enum with a unit struct
Closes #429

## Changes

Change the empty struct to emit `Record<symbol, never>` instead of `Record<string, never>`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
