### PR TITLE
Add optional_fields to enum

### DIFF
--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -64,6 +64,7 @@ impl StructAttr {
                 },
                 _ => None,
             },
+            optional_fields: enum_attr.optional_fields,
 
             // inline and skip are not supported on StructAttr
             ..Self::default()

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -64,7 +64,7 @@ impl StructAttr {
                 },
                 _ => None,
             },
-            optional_fields: enum_attr.optional_fields,
+            optional_fields: enum_attr.optional_fields.or(variant_attr.optional_fields),
 
             // inline and skip are not supported on StructAttr
             ..Self::default()

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -64,7 +64,10 @@ impl StructAttr {
                 },
                 _ => None,
             },
-            optional_fields: enum_attr.optional_fields.or(variant_attr.optional_fields),
+            optional_fields: match (enum_attr.optional_fields, variant_attr.optional_fields) {
+                (parent, Optional::Inherit) => parent,
+                (_, child) => child,
+            },
 
             // inline and skip are not supported on StructAttr
             ..Self::default()

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -3,6 +3,7 @@ use syn::{Attribute, Expr, Fields, Ident, Result, Type, Variant};
 use super::{parse_assign_expr, Attr, Serde};
 use crate::{
     attr::{parse_assign_from_str, parse_assign_inflection, parse_assign_str, Inflection},
+    optional::{parse_optional, Optional},
     utils::parse_attrs,
 };
 
@@ -15,6 +16,7 @@ pub struct VariantAttr {
     pub inline: bool,
     pub skip: bool,
     pub untagged: bool,
+    pub optional_fields: Optional,
 }
 
 impl VariantAttr {
@@ -40,6 +42,7 @@ impl Attr for VariantAttr {
             inline: self.inline || other.inline,
             skip: self.skip || other.skip,
             untagged: self.untagged || other.untagged,
+            optional_fields: self.optional_fields.or(other.optional_fields),
         }
     }
 
@@ -96,6 +99,7 @@ impl_parse! {
         "inline" => out.inline = true,
         "skip" => out.skip = true,
         "untagged" => out.untagged = true,
+        "optional_fields" => out.optional_fields = parse_optional(input)?,
     }
 }
 

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -26,7 +26,7 @@ impl Optional {
         match (self, other) {
             (Self::Inherit, other) | (other, Self::Inherit) => other,
             (Self::Optional { nullable: a }, Self::Optional { nullable: b }) => {
-                Self::Optional { nullable: a || b }
+                Self::Optional { nullable: a && b }
             }
             _ => other,
         }

--- a/macros/src/optional.rs
+++ b/macros/src/optional.rs
@@ -26,7 +26,7 @@ impl Optional {
         match (self, other) {
             (Self::Inherit, other) | (other, Self::Inherit) => other,
             (Self::Optional { nullable: a }, Self::Optional { nullable: b }) => {
-                Self::Optional { nullable: a && b }
+                Self::Optional { nullable: a || b }
             }
             _ => other,
         }

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -141,6 +141,14 @@ struct NullableStruct {
 
     #[ts(as = "String")]
     h: Option<i32>,
+
+    // not nullable
+    #[ts(optional)]
+    i: Option<i32>,
+
+    // not optional
+    #[ts(optional = false)]
+    j: Option<i32>,
 }
 
 #[test]
@@ -148,7 +156,7 @@ fn struct_nullable() {
     assert_eq!(
         NullableStruct::inline(),
         format!(
-            "{{ a?: number | null, b?: number | null, c?: number | null, d: number, e?: number | null, f?: number | null, g: string, h: string, }}"
+            "{{ a?: number | null, b?: number | null, c?: number | null, d: number, e?: number | null, f?: number | null, g: string, h: string, i?: number, j: number | null, }}"
         )
     )
 }
@@ -217,6 +225,18 @@ enum OptionalFieldsEnum {
 }
 
 #[derive(Serialize, TS)]
+#[ts(export, export_to = "optional_field/", optional_fields = nullable)]
+enum OptionalFieldsEnumVariantOverride {
+    // Disable `nullable`
+    #[ts(optional_fields)]
+    A { a: Option<i32> },
+
+    // Disable `optional_fields`
+    #[ts(optional_fields = false)]
+    B { b: String, c: Option<bool> },
+}
+
+#[derive(Serialize, TS)]
 #[ts(export, export_to = "optional_field/", optional_fields, tag = "type")]
 enum OptionalFieldsTaggedEnum {
     A { a: Option<i32> },
@@ -241,6 +261,11 @@ fn optional_fields_enum() {
     assert_eq!(
         OptionalFieldsEnum::inline(),
         r#"{ "A": { a?: number, } } | { "B": { b: string, c?: boolean, } }"#
+    );
+
+    assert_eq!(
+        OptionalFieldsEnumVariantOverride::inline(),
+        r#"{ "A": { a?: number, } } | { "B": { b: string, c: boolean | null, } }"#
     );
 
     assert_eq!(

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -237,6 +237,18 @@ enum OptionalFieldsEnumVariantOverride {
 }
 
 #[derive(Serialize, TS)]
+#[ts(export, export_to = "optional_field/", optional_fields)]
+enum OptionalFieldsEnumNotNullableVariantOverride {
+    // Disable `nullable`
+    #[ts(optional_fields = nullable)]
+    A { a: Option<i32> },
+
+    // Disable `optional_fields`
+    #[ts(optional_fields = false)]
+    B { b: String, c: Option<bool> },
+}
+
+#[derive(Serialize, TS)]
 #[ts(export, export_to = "optional_field/", optional_fields, tag = "type")]
 enum OptionalFieldsTaggedEnum {
     A { a: Option<i32> },
@@ -266,6 +278,11 @@ fn optional_fields_enum() {
     assert_eq!(
         OptionalFieldsEnumVariantOverride::inline(),
         r#"{ "A": { a?: number, } } | { "B": { b: string, c: boolean | null, } }"#
+    );
+
+    assert_eq!(
+        OptionalFieldsEnumNotNullableVariantOverride::inline(),
+        r#"{ "A": { a?: number | null, } } | { "B": { b: string, c: boolean | null, } }"#
     );
 
     assert_eq!(

--- a/ts-rs/tests/integration/optional_field.rs
+++ b/ts-rs/tests/integration/optional_field.rs
@@ -208,3 +208,48 @@ fn tuple_nullable() {
         "[number, string, string, (number | null)?, (number)?, (number | null)?]"
     );
 }
+
+#[derive(Serialize, TS)]
+#[ts(export, export_to = "optional_field/", optional_fields)]
+enum OptionalFieldsEnum {
+    A { a: Option<i32> },
+    B { b: String, c: Option<bool> },
+}
+
+#[derive(Serialize, TS)]
+#[ts(export, export_to = "optional_field/", optional_fields, tag = "type")]
+enum OptionalFieldsTaggedEnum {
+    A { a: Option<i32> },
+    B { b: String, c: Option<bool> },
+}
+
+#[derive(Serialize, TS)]
+#[ts(
+    export,
+    export_to = "optional_field/",
+    optional_fields,
+    tag = "type",
+    content = "data"
+)]
+enum OptionalFieldsExternallyTaggedEnum {
+    A { a: Option<i32> },
+    B { b: String, c: Option<bool> },
+}
+
+#[test]
+fn optional_fields_enum() {
+    assert_eq!(
+        OptionalFieldsEnum::inline(),
+        r#"{ "A": { a?: number, } } | { "B": { b: string, c?: boolean, } }"#
+    );
+
+    assert_eq!(
+        OptionalFieldsTaggedEnum::inline(),
+        r#"{ "type": "A", a?: number, } | { "type": "B", b: string, c?: boolean, }"#
+    );
+
+    assert_eq!(
+        OptionalFieldsExternallyTaggedEnum::inline(),
+        r#"{ "type": "A", "data": { a?: number, } } | { "type": "B", "data": { b: string, c?: boolean, } }"#
+    );
+}


### PR DESCRIPTION
## Goal

Add support for `#[ts(optional_fields)]` in enums and enum variants
Closes #427

## Changes

Parse the `optional_fields` attribute in enums and provide it to the variants when in `format_variant`

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
