### PR TITLE
Updated chrono Duration emitted type

### DIFF
--- a/ts-rs/src/chrono.rs
+++ b/ts-rs/src/chrono.rs
@@ -23,7 +23,8 @@ macro_rules! impl_dummy {
     )*};
 }
 
-impl_primitives!(NaiveDateTime, NaiveDate, NaiveTime, Month, Weekday, Duration => "string");
+impl_primitives!(NaiveDateTime, NaiveDate, NaiveTime, Month, Weekday => "string");
+impl_primitives!(Duration => "[number, number]");
 impl_dummy!(Utc, Local, FixedOffset);
 
 impl<T: TimeZone + 'static> TS for DateTime<T> {

--- a/ts-rs/tests/integration/chrono.rs
+++ b/ts-rs/tests/integration/chrono.rs
@@ -27,6 +27,6 @@ struct Chrono {
 fn chrono() {
     assert_eq!(
         Chrono::decl(),
-        "type Chrono = { date: [string, string, string, string], time: string, date_time: [string, string, string, string], duration: string, month: string, weekday: string, };"
-    )
+        "type Chrono = { date: [string, string, string, string], time: string, date_time: [string, string, string, string], duration: [number, number], month: string, weekday: string, };"
+    );
 }


### PR DESCRIPTION
## Goal

What is this PR attempting to achieve? Is it a bug fix? Is it related to an issue?
Closes #433

## Changes

How did you go about solving the problem?

In file `ts-rs/src/chrono.rs`, I have added the line
```rs
impl_primitives!(Duration => "[number, number]");
```
To cause `[number, number]` to be emitted for the type `Duration` in `chrono::`

## Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [X] I have added or updated the tests related to the changes made.
