### PR TITLE
Ignore `#[serde(crate = ...)]`

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -289,5 +289,10 @@ impl_parse! {
         "content" => out.0.content = Some(parse_assign_str(input)?),
         "untagged" => out.0.untagged = true,
         "bound" => out.0.bound = Some(parse_bound(input)?),
+
+        // parse #[serde(crate = "...")] to not emit a warning
+        "crate" => {
+            parse_assign_str(input)?;
+        }
     }
 }

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -180,5 +180,10 @@ impl_parse! {
                 parse_assign_str(input)?;
             }
         },
+
+        // parse #[serde(crate = "...")] to not emit a warning
+        "crate" => {
+            parse_assign_str(input)?;
+        }
     }
 }


### PR DESCRIPTION
## Goal

Parse `#[serde(crate = "...")]` to avoid emitting warning
Closes #443

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
