### PR TITLE
opt out of automatic export of bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ export type User = { user_id: number, first_name: string, last_name: string, };
 | smol_str-impl      | Implement `TS` for types from *smol_str*                                                                                                                                                                  |
 | tokio-impl         | Implement `TS` for types from *tokio*                                                                                                                                                                     |
 | jiff-impl          | Implement `TS` for types from *jiff*                                                                                                                                                                      |
+| export-bindings    | **Enabled by default** <br/>See the section below on "controlling binding generation" for more information.                                                                                               |
 
 <br/>
 
@@ -130,6 +131,34 @@ When ts-rs encounters an unsupported serde attribute, a warning is emitted, unle
 | `TS_RS_IMPORT_EXTENSION` | File extension used in `import` statements                          | *none*       |
 | `TS_RS_LARGE_INT`        | Binding used for large integer types (`i64`, `u64`, `i128`, `u128`) | `bigint`     |
 
+### Controlling when the bindings are generated
+
+Feature "export-bindings", which is enabled by default, instructs ts-rs to export the bindings
+when you run `cargo test`. This behavior may be undesirable if you need to export only at a
+specific time (e.g., during `./configure` or a build pipeline.)
+
+To opt out of this automatic binding generation, disable the default features in your
+Cargo.toml:
+
+```toml
+[dependencies]
+ts-rs = { version = "11", default-features = false, features = [
+  "serde-compat",
+  "no-serde-warnings",
+] }
+```
+
+Now, you may export the bindings on demand using the `--features` flag:
+
+```bash
+cargo test --features ts-rs/export-bindings
+```
+
+Or, if you want to merely export the bindings and run no other tests:
+
+```bash
+cargo test --features ts-rs/export-bindings -- 'export_bindings_'
+```
 
 ### Contributing
 Contributions are always welcome!

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,8 +9,10 @@ homepage = "https://github.com/Aleph-Alpha/ts-rs"
 repository = "https://github.com/Aleph-Alpha/ts-rs"
 
 [features]
+default = ["export-bindings"]
 serde-compat = ["termcolor"]
 no-serde-warnings = []
+export-bindings = []
 
 [lib]
 proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{
     parse_quote, spanned::Spanned, ConstParam, Expr, GenericParam, Generics, Item, LifetimeParam,
     Path, Result, Type, TypeArray, TypeParam, TypeParen, TypePath, TypeReference, TypeSlice,
@@ -181,8 +181,9 @@ impl DerivedTS {
         }
     }
 
+    #[cfg(feature = "export-bindings")]
     fn generate_export_test(&self, rust_ty: &Ident, generics: &Generics) -> TokenStream {
-        let test_fn = format_ident!(
+        let test_fn = quote::format_ident!(
             "export_bindings_{}",
             rust_ty.to_string().to_lowercase().replace("r#", "")
         );
@@ -202,6 +203,10 @@ impl DerivedTS {
                 #ty::export_all().expect("could not export type");
             }
         }
+    }
+    #[cfg(not(feature = "export-bindings"))]
+    fn generate_export_test(&self, _rust_ty: &Ident, _generics: &Generics) -> TokenStream {
+        quote! {}
     }
 
     fn generate_generics_fn(&self, generics: &Generics) -> TokenStream {

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -18,7 +18,7 @@ readme = "../README.md"
 rust-version = "1.78.0"
 
 [features]
-default = ["serde-compat"]
+default = ["serde-compat", "export-bindings"]
 
 chrono-impl = ["chrono"]
 bigdecimal-impl = ["bigdecimal"]
@@ -38,6 +38,7 @@ no-serde-warnings = ["ts-rs-macros/no-serde-warnings"]
 import-esm = []
 tokio-impl = ["tokio"]
 jiff-impl = ["jiff"]
+export-bindings = ["ts-rs-macros/export-bindings"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -46,7 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1.40", features = ["sync", "rt"] }
 
 [dependencies]
-ts-rs-macros = { version = "=11.1.0", path = "../macros" }
+ts-rs-macros = { version = "=11.1.0", path = "../macros", default-features = false }
 thiserror = "2"
 
 heapless = { version = ">= 0.7, < 0.9", optional = true }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -92,6 +92,7 @@
 //! | smol_str-impl      | Implement `TS` for types from *smol_str*                                                                                                                                                                  |
 //! | tokio-impl         | Implement `TS` for types from *tokio*                                                                                                                                                                     |
 //! | jiff-impl          | Implement `TS` for types from *jiff*                                                                                                                                                                      |
+//! | export-bindings    | **Enabled by default** <br/>See the section below on "controlling binding generation" for more information.                                                                                               |
 //!
 //! <br/>
 //!
@@ -128,6 +129,34 @@
 //! | `TS_RS_IMPORT_EXTENSION` | File extension used in `import` statements                          | *none*       |
 //! | `TS_RS_LARGE_INT`        | Binding used for large integer types (`i64`, `u64`, `i128`, `u128`) | `bigint`     |
 //!
+//! ## Controlling when the bindings are generated
+//!
+//! Feature "export-bindings", which is enabled by default, instructs ts-rs to export the bindings
+//! when you run `cargo test`. This behavior may be undesirable if you need to export only at a
+//! specific time (e.g., during `./configure` or a build pipeline.)
+//!
+//! To opt out of this automatic binding generation, disable the default features in your
+//! Cargo.toml:
+//!
+//! ```toml
+//! [dependencies]
+//! ts-rs = { version = "11", default-features = false, features = [
+//!   "serde-compat",
+//!   "no-serde-warnings",
+//! ] }
+//! ```
+//!
+//! Now, you may export the bindings on demand using the `--features` flag:
+//!
+//! ```bash
+//! cargo test --features ts-rs/export-bindings
+//! ```
+//!
+//! Or, if you want to merely export the bindings and run no other tests:
+//!
+//! ```bash
+//! cargo test --features ts-rs/export-bindings -- 'export_bindings_'
+//! ```
 //!
 //! ## Contributing
 //! Contributions are always welcome!


### PR DESCRIPTION
this patch introduces a new feature - "export-bindings" - to grant downstream more control over when the bindings are generated.

With the feature disabled in Cargo.toml, the bindings are not exported automatically on every test run. The user can choose when to export by explicitly enabling the feature with the --features cargo test flag.

For example, in my Cargo.toml:

```toml
[dependencies]
ts-rs = { version = "11", default-features = false, features = [
  "serde-compat",
  "no-serde-warnings",
] }
```

And at the time I need to export the bindings:

    cargo test --features export-bindings -- 'export_bindings_'

This is somewhat related to #62 and #253.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
