### PR TITLE
Parse #[serde(borrow)] to not emit warnings

### DIFF
--- a/macros/src/attr/mod.rs
+++ b/macros/src/attr/mod.rs
@@ -141,6 +141,15 @@ fn parse_assign_str(input: ParseStream) -> Result<String> {
     }
 }
 
+fn parse_optional_assign_str(input: ParseStream) -> Result<Option<String>> {
+    if input.peek(Token![=]) {
+        Some(parse_assign_str(input))
+    } else {
+        None
+    }
+    .transpose()
+}
+
 fn parse_concrete(input: ParseStream) -> Result<HashMap<syn::Ident, syn::Type>> {
     struct Concrete {
         ident: syn::Ident,

--- a/macros/src/attr/struct.rs
+++ b/macros/src/attr/struct.rs
@@ -7,7 +7,7 @@ use super::{
     Attr, ContainerAttr, Serde, Tagged,
 };
 use crate::{
-    attr::{parse_assign_str, EnumAttr, Inflection, VariantAttr},
+    attr::{parse_assign_str, parse_optional_assign_str, EnumAttr, Inflection, VariantAttr},
     optional::{parse_optional, Optional},
     utils::{extract_docs, parse_attrs},
 };
@@ -172,13 +172,8 @@ impl_parse! {
         "bound" => out.0.bound = Some(parse_bound(input)?),
         // parse #[serde(default)] to not emit a warning
         "deny_unknown_fields" | "default" => {
-            use syn::Token;
-            if input.peek(Token![=]) {
-                input.parse::<Token![=]>()?;
-                parse_assign_str(input)?;
-            }
+            parse_optional_assign_str(input)?;
         },
-
         // parse #[serde(crate = "...")] to not emit a warning
         "crate" => {
             parse_assign_str(input)?;

--- a/macros/src/attr/variant.rs
+++ b/macros/src/attr/variant.rs
@@ -2,7 +2,10 @@ use syn::{Attribute, Expr, Fields, Ident, Result, Type, Variant};
 
 use super::{parse_assign_expr, Attr, Serde};
 use crate::{
-    attr::{parse_assign_from_str, parse_assign_inflection, parse_assign_str, Inflection},
+    attr::{
+        parse_assign_from_str, parse_assign_inflection, parse_assign_str,
+        parse_optional_assign_str, Inflection,
+    },
     optional::{parse_optional, Optional},
     utils::parse_attrs,
 };
@@ -109,5 +112,9 @@ impl_parse! {
         "rename_all" => out.0.rename_all = Some(parse_assign_inflection(input)?),
         "skip" => out.0.skip = true,
         "untagged" => out.0.untagged = true,
+        // parse #[serde(borrow)] or `#[serde(borrow = "..")]` to not emit a warning
+        "borrow" => {
+            parse_optional_assign_str(input)?;
+        },
     }
 }


### PR DESCRIPTION
## Goal

Closes #436

Eagerly parses `#[serde(borrow)]` and ignores it, in order to not emit any warnings for it.

## Changes

Also fixes a `=` that was parsed from `ParseStream` twice.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
