### PR TITLE
Allow `#[ts(flatten)]` for unit structs

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -245,6 +245,15 @@ impl Attr for EnumAttr {
                 item;
                 "content cannot be used without tag"
             ),
+            (false, Some(_), None) => {
+                for variant in item.variants.iter() {
+                    if let Fields::Unnamed(ref unnamed) = variant.fields {
+                        if unnamed.unnamed.len() > 1 {
+                            syn_err_spanned!(variant; r#"`#[ts(tag = "...")]` cannot be used with tuple variants"#);
+                        }
+                    }
+                }
+            }
             _ => (),
         };
 

--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -248,6 +248,15 @@ impl Attr for EnumAttr {
                 item;
                 "content cannot be used without tag"
             ),
+            (false, Some(_), None) => {
+                for variant in item.variants.iter() {
+                    if let Fields::Unnamed(ref unnamed) = variant.fields {
+                        if unnamed.unnamed.len() > 1 {
+                            syn_err_spanned!(variant; r#"`#[ts(tag = "...")]` cannot be used with tuple variants"#);
+                        }
+                    }
+                }
+            }
             _ => (),
         };
 

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -51,7 +51,7 @@ pub(crate) fn null(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
     DerivedTS {
         crate_rename: crate_rename.clone(),
         inline: quote!("null".to_owned()),
-        inline_flattened: None,
+        inline_flattened: Some(quote!("{ }".to_owned())),
         docs: attr.docs.clone(),
         dependencies: Dependencies::new(crate_rename),
         export: attr.export,

--- a/macros/src/types/unit.rs
+++ b/macros/src/types/unit.rs
@@ -13,7 +13,7 @@ pub(crate) fn empty_object(attr: &StructAttr, ts_name: Expr) -> DerivedTS {
     DerivedTS {
         crate_rename: crate_rename.clone(),
         inline: quote!("Record<symbol, never>".to_owned()),
-        inline_flattened: None,
+        inline_flattened: Some(quote!("{ }".to_owned())),
         docs: attr.docs.clone(),
         dependencies: Dependencies::new(crate_rename),
         export: attr.export,

--- a/ts-rs/tests/integration/flatten.rs
+++ b/ts-rs/tests/integration/flatten.rs
@@ -29,6 +29,19 @@ struct C {
     d: i32,
 }
 
+#[derive(TS)]
+#[ts(export, export_to = "flatten/")]
+pub struct Inner {}
+
+// Create a parent struct that flattens the zero-field struct:
+#[derive(TS)]
+#[ts(export, export_to = "flatten/")]
+pub struct Outer {
+    #[ts(flatten)]
+    pub inner: Inner,
+    pub other_field: String,
+}
+
 #[test]
 fn test_def() {
     let cfg = Config::from_env();
@@ -36,4 +49,5 @@ fn test_def() {
         C::inline(&cfg),
         "{ b: { c: number, a: number, b: number, } & ({ [key in string]: number }), d: number, }"
     );
+    assert_eq!(Outer::inline(&cfg), "{ other_field: string, }");
 }


### PR DESCRIPTION
## Goal

Allow the use of `#[ts(flatten)]` with unit structs `struct Foo;` and empty structs `struct Foo {}` but not empty tuple structs `struct Foo()`. This matches the behavior of `#[serde(flatten)]`

The use of the type `{ }` when flattening these structs does not cause the `{}` type to appear in typescript because of our `.replace(" } & { ")` which we added back when we first changed the implementation of `flatten` to use type intersections, which means these structs simply disappear from the ts type as though `#[ts(skip)]` was used instead, which also matches serde behavior.

Allowing `flatten` on `struct Foo;` (no curly braces) broke the generation of internally tagged enums because it caused an interaction with the `struct` version of `#[ts(tag = "...")]`, but this ended up making the enum generation code simpler as it removed an unnecessary `match` expression and the need to manually add the internal tag, as the `struct` version of this attribute does it instead

Also added a validation rule to prevent the use of internal tagging (`#[ts(tag = "...")]` without `#[ts(content = "...")]`) when the enum contains tuple variants,
Closes #473

## Changes

How did you go about solving the problem?

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
