### PR TITLE
fix: detect and error on TS type name collisions during export

### DIFF
--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -163,7 +163,23 @@ fn export_and_merge(
     };
 
     if entry.contains(&type_name) {
-        return Ok(());
+        let existing_contents = std::fs::read_to_string(&path)?;
+        // Idempotent re-run: same content → allow
+        if existing_contents == generated_type {
+            return Ok(());
+        }
+        // Merged file: check if the declaration is already present verbatim
+        if let Some((_, new_decl)) = generated_type.split_once("\n\n") {
+            let new_decl = new_decl.trim();
+            if existing_contents.contains(new_decl) {
+                return Ok(());
+            }
+        }
+        return Err(ExportError::Collision {
+            path: path.clone(),
+            existing_types: entry.iter().cloned().collect::<Vec<_>>().join(", "),
+            new_type: type_name,
+        });
     }
 
     let mut file = std::fs::OpenOptions::new()

--- a/ts-rs/src/export/error.rs
+++ b/ts-rs/src/export/error.rs
@@ -14,4 +14,15 @@ pub enum ExportError {
     Fmt(#[from] std::fmt::Error),
     #[error(r#"TS_RS_IMPORT_EXTENSION must be either "js" or "ts""#)]
     InvalidImportExtension,
+    #[error(
+        "type name collision for \"{new_type}\" in {}: two different types generate different \
+         content for the same file. Use #[ts(rename = \"...\")] or #[ts(export_to = \"...\")] \
+         to disambiguate.",
+        path.display()
+    )]
+    Collision {
+        path: std::path::PathBuf,
+        existing_types: String,
+        new_type: String,
+    },
 }

--- a/ts-rs/tests/integration/collision.rs
+++ b/ts-rs/tests/integration/collision.rs
@@ -1,0 +1,40 @@
+use ts_rs::TS;
+
+#[derive(TS)]
+#[ts(rename = "Idempotent", export_to = "collision/Idempotent.ts")]
+struct Idempotent {
+    a: String,
+}
+
+#[derive(TS)]
+#[ts(rename = "Colliding", export_to = "collision/Colliding.ts")]
+struct CollidingA {
+    x: i32,
+}
+
+#[derive(TS)]
+#[ts(rename = "Colliding", export_to = "collision/Colliding.ts")]
+struct CollidingB {
+    y: bool,
+    z: String,
+}
+
+#[test]
+fn idempotent_export() {
+    let cfg = ts_rs::Config::default();
+    Idempotent::export_all(&cfg).unwrap();
+    // Second export of the exact same type should succeed
+    Idempotent::export_all(&cfg).unwrap();
+}
+
+#[test]
+fn collision_is_detected() {
+    let cfg = ts_rs::Config::default();
+    CollidingA::export_all(&cfg).unwrap();
+    let err = CollidingB::export_all(&cfg).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Colliding"),
+        "error should mention the colliding type name, got: {msg}"
+    );
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod arrayvec;
 mod bound;
 mod bson;
 mod chrono;
+mod collision;
 mod complex_flattened_type;
 mod concrete_generic;
 mod docs;


### PR DESCRIPTION
## Summary

- **Bug**: When two different Rust types both `#[derive(TS)]` with the same TypeScript name (e.g. via `#[ts(rename = "...")]`), they write to the same output file. The current behavior at `export_and_merge` line 165-167 is **silent last-writer-wins** — the second type is silently dropped with `return Ok(())`, producing nondeterministic TypeScript output.
- **Fix**: Replace the silent skip with a content comparison. If the file content matches exactly (idempotent re-run), allow it. If the declaration is already present in a merged file, allow it. Otherwise, return a new `ExportError::Collision` with an actionable error message suggesting `#[ts(rename = "...")]` or `#[ts(export_to = "...")]` to disambiguate.
- **Tests**: Two new integration tests — `idempotent_export` (same type twice succeeds) and `collision_is_detected` (different types with same TS name errors).

## What stays the same

- Multi-type-per-file merging (different names, same file via `export_to`) — untouched
- Cross-process first-write behavior (overwrite on fresh run) — unchanged
- `EXPORT_PATHS` static type signature — unchanged

## Test plan

- [x] `cargo test --all-features --test integration collision` — new tests pass
- [x] `cargo test --no-default-features --test integration collision` — passes without serde-compat
- [x] `cargo test --all-features --test integration same_file_export` — existing regression guard passes
- [x] `cargo test --all-features` — full suite (528+ tests) passes with zero failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)