### PR TITLE
feat: opt-in auto-namespace by crate name to avoid type collisions

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -111,6 +111,10 @@ impl DerivedTS {
                 #generics_fn
                 #output_path_fn
 
+                fn crate_name() -> Option<&'static str> {
+                    Some(env!("CARGO_PKG_NAME"))
+                }
+
                 fn visit_dependencies(v: &mut impl #crate_rename::TypeVisitor)
                 where
                     Self: 'static,

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -85,11 +85,24 @@ mod recursive_export {
     }
 }
 
+/// When auto_namespace is enabled and crate_name is available, returns
+/// the path prefixed with `{crate_name}/`. Otherwise returns the path unchanged.
+pub(crate) fn maybe_namespace<T: TS + ?Sized>(cfg: &Config, path: PathBuf) -> PathBuf {
+    if cfg.auto_namespace() {
+        if let Some(crate_name) = <T as TS>::crate_name() {
+            let ns = crate_name.replace('-', "_");
+            return PathBuf::from(ns).join(path);
+        }
+    }
+    path
+}
+
 /// Export `T` to the file specified by the `#[ts(export_to = ..)]` attribute
 pub(crate) fn export_into<T: TS + ?Sized + 'static>(cfg: &Config) -> Result<(), ExportError> {
     let path = <T as crate::TS>::output_path()
         .ok_or_else(std::any::type_name::<T>)
         .map_err(ExportError::CannotBeExported)?;
+    let path = maybe_namespace::<T>(cfg, path);
     let path = cfg.export_dir.join(path);
 
     export_to::<T, _>(cfg, path::absolute(path)?)
@@ -345,6 +358,7 @@ fn generate_imports<T: TS + ?Sized + 'static>(
 ) -> Result<(), ExportError> {
     let path = <T as crate::TS>::output_path()
         .ok_or_else(std::any::type_name::<T>)
+        .map(|x| maybe_namespace::<T>(cfg, x))
         .map(|x| cfg.export_dir.join(x))
         .map_err(ExportError::CannotBeExported)?;
 

--- a/ts-rs/src/export.rs
+++ b/ts-rs/src/export.rs
@@ -163,7 +163,23 @@ fn export_and_merge(
     };
 
     if entry.contains(&type_name) {
-        return Ok(());
+        let existing_contents = std::fs::read_to_string(&path)?;
+        // Idempotent re-run: same content → allow
+        if existing_contents == generated_type {
+            return Ok(());
+        }
+        // Merged file: check if the declaration is already present verbatim
+        if let Some((_, new_decl)) = generated_type.split_once("\n\n") {
+            let new_decl = new_decl.trim();
+            if existing_contents.contains(new_decl) {
+                return Ok(());
+            }
+        }
+        return Err(ExportError::Collision {
+            path: path.clone(),
+            existing_types: entry.iter().cloned().collect::<Vec<_>>().join(", "),
+            new_type: type_name,
+        });
     }
 
     let mut file = std::fs::OpenOptions::new()

--- a/ts-rs/src/export/error.rs
+++ b/ts-rs/src/export/error.rs
@@ -17,7 +17,7 @@ pub enum ExportError {
     #[error(
         "type name collision for \"{new_type}\" in {}: two different types generate different \
          content for the same file. Use #[ts(rename = \"...\")] or #[ts(export_to = \"...\")] \
-         to disambiguate.",
+         to disambiguate, or set TS_RS_AUTO_NAMESPACE=true to organize types by crate.",
         path.display()
     )]
     Collision {

--- a/ts-rs/src/export/error.rs
+++ b/ts-rs/src/export/error.rs
@@ -14,4 +14,15 @@ pub enum ExportError {
     Fmt(#[from] std::fmt::Error),
     #[error(r#"TS_RS_IMPORT_EXTENSION must be either "js" or "ts""#)]
     InvalidImportExtension,
+    #[error(
+        "type name collision for \"{new_type}\" in {}: two different types generate different \
+         content for the same file. Use #[ts(rename = \"...\")] or #[ts(export_to = \"...\")] \
+         to disambiguate.",
+        path.display()
+    )]
+    Collision {
+        path: std::path::PathBuf,
+        existing_types: String,
+        new_type: String,
+    },
 }

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -492,6 +492,7 @@ pub trait TS {
         let relative_path = Self::output_path()
             .ok_or_else(std::any::type_name::<Self>)
             .map_err(ExportError::CannotBeExported)?;
+        let relative_path = export::maybe_namespace::<Self>(cfg, relative_path);
         let path = cfg.export_dir.join(relative_path);
 
         export::export_to::<Self, _>(cfg, path)
@@ -539,6 +540,12 @@ pub trait TS {
     fn output_path() -> Option<PathBuf> {
         None
     }
+
+    /// Returns the Cargo package name of the crate that defined this type.
+    /// Used for auto-namespacing when `Config::auto_namespace` is enabled.
+    fn crate_name() -> Option<&'static str> {
+        None
+    }
 }
 
 /// A visitor used to iterate over all dependencies or generics of a type.
@@ -568,7 +575,13 @@ impl Dependency {
     /// If `T` is not exportable (meaning `T::EXPORT_TO` is `None`), this function will return
     /// `None`
     pub fn from_ty<T: TS + 'static + ?Sized>(cfg: &Config) -> Option<Self> {
-        let output_path = <T as crate::TS>::output_path()?;
+        let mut output_path = <T as crate::TS>::output_path()?;
+        if cfg.auto_namespace() {
+            if let Some(crate_name) = <T as crate::TS>::crate_name() {
+                let ns = crate_name.replace('-', "_");
+                output_path = PathBuf::from(ns).join(output_path);
+            }
+        }
         Some(Dependency {
             type_id: TypeId::of::<T>(),
             ts_name: <T as crate::TS>::ident(cfg),
@@ -588,6 +601,8 @@ pub struct Config {
     // TS_RS_IMPORT_EXTENSION
     import_extension: Option<String>,
     array_tuple_limit: usize,
+    // TS_RS_AUTO_NAMESPACE
+    auto_namespace: bool,
 }
 
 impl Default for Config {
@@ -598,6 +613,7 @@ impl Default for Config {
             export_dir: "./bindings".into(),
             import_extension: None,
             array_tuple_limit: 64,
+            auto_namespace: false,
         }
     }
 }
@@ -635,6 +651,10 @@ impl Config {
         #[allow(deprecated)]
         if let Ok("1" | "true" | "on" | "yes") = std::env::var("TS_RS_USE_V11_HASHMAP").as_deref() {
             cfg = cfg.with_v11_hashmap();
+        }
+
+        if let Ok("1" | "true" | "on" | "yes") = std::env::var("TS_RS_AUTO_NAMESPACE").as_deref() {
+            cfg.auto_namespace = true;
         }
 
         cfg
@@ -705,6 +725,21 @@ impl Config {
     /// Returns the maximum size of arrays (`[T; N]`) up to which they are treated as TypeScript tuples (`[T, T, ...]`).  
     pub fn array_tuple_limit(&self) -> usize {
         self.array_tuple_limit
+    }
+
+    /// When enabled, exported types are organized into `{crate_name}/` subdirectories
+    /// based on the crate that defined them. This prevents type name collisions between
+    /// different crates.
+    ///
+    /// Default: `false`
+    pub fn with_auto_namespace(mut self, enabled: bool) -> Self {
+        self.auto_namespace = enabled;
+        self
+    }
+
+    /// Returns whether auto-namespacing by crate name is enabled.
+    pub fn auto_namespace(&self) -> bool {
+        self.auto_namespace
     }
 }
 

--- a/ts-rs/tests/integration/auto_namespace.rs
+++ b/ts-rs/tests/integration/auto_namespace.rs
@@ -1,0 +1,214 @@
+use std::path::PathBuf;
+
+use ts_rs::{Config, ExportError, TypeVisitor, TS};
+
+// -- Manual TS impls for testing cross-crate behavior --
+
+struct NsTypeA;
+impl TS for NsTypeA {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+    fn name(_: &Config) -> String {
+        "NsColliding".to_owned()
+    }
+    fn inline(_: &Config) -> String {
+        "{ a: string }".to_owned()
+    }
+    fn decl(_: &Config) -> String {
+        "type NsColliding = { a: string };".to_owned()
+    }
+    fn decl_concrete(cfg: &Config) -> String {
+        Self::decl(cfg)
+    }
+    fn output_path() -> Option<PathBuf> {
+        Some(PathBuf::from("NsColliding.ts"))
+    }
+    fn crate_name() -> Option<&'static str> {
+        Some("crate_a")
+    }
+}
+
+struct NsTypeB;
+impl TS for NsTypeB {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+    fn name(_: &Config) -> String {
+        "NsColliding".to_owned()
+    }
+    fn inline(_: &Config) -> String {
+        "{ b: number }".to_owned()
+    }
+    fn decl(_: &Config) -> String {
+        "type NsColliding = { b: number };".to_owned()
+    }
+    fn decl_concrete(cfg: &Config) -> String {
+        Self::decl(cfg)
+    }
+    fn output_path() -> Option<PathBuf> {
+        Some(PathBuf::from("NsColliding.ts"))
+    }
+    fn crate_name() -> Option<&'static str> {
+        Some("crate_b")
+    }
+}
+
+struct NsDep;
+impl TS for NsDep {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+    fn name(_: &Config) -> String {
+        "NsDep".to_owned()
+    }
+    fn inline(_: &Config) -> String {
+        "{ val: string }".to_owned()
+    }
+    fn decl(_: &Config) -> String {
+        "type NsDep = { val: string };".to_owned()
+    }
+    fn decl_concrete(cfg: &Config) -> String {
+        Self::decl(cfg)
+    }
+    fn output_path() -> Option<PathBuf> {
+        Some(PathBuf::from("NsDep.ts"))
+    }
+    fn crate_name() -> Option<&'static str> {
+        Some("dep_crate")
+    }
+}
+
+struct NsParent;
+impl TS for NsParent {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+    fn name(_: &Config) -> String {
+        "NsParent".to_owned()
+    }
+    fn inline(cfg: &Config) -> String {
+        format!("{{ dep: {} }}", NsDep::inline(cfg))
+    }
+    fn decl(cfg: &Config) -> String {
+        format!("type NsParent = {};", Self::inline(cfg))
+    }
+    fn decl_concrete(cfg: &Config) -> String {
+        Self::decl(cfg)
+    }
+    fn output_path() -> Option<PathBuf> {
+        Some(PathBuf::from("NsParent.ts"))
+    }
+    fn crate_name() -> Option<&'static str> {
+        Some("parent_crate")
+    }
+    fn visit_dependencies(v: &mut impl TypeVisitor)
+    where
+        Self: 'static,
+    {
+        v.visit::<NsDep>();
+    }
+}
+
+struct NsHyphenType;
+impl TS for NsHyphenType {
+    type WithoutGenerics = Self;
+    type OptionInnerType = Self;
+    fn name(_: &Config) -> String {
+        "NsHyphenType".to_owned()
+    }
+    fn inline(_: &Config) -> String {
+        "{ x: number }".to_owned()
+    }
+    fn decl(_: &Config) -> String {
+        "type NsHyphenType = { x: number };".to_owned()
+    }
+    fn decl_concrete(cfg: &Config) -> String {
+        Self::decl(cfg)
+    }
+    fn output_path() -> Option<PathBuf> {
+        Some(PathBuf::from("NsHyphenType.ts"))
+    }
+    fn crate_name() -> Option<&'static str> {
+        Some("my-crate")
+    }
+}
+
+fn unique_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir()
+        .join("ts_rs_auto_ns_tests")
+        .join(name);
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn auto_namespace_separates_crates() {
+    let dir = unique_dir("separates_crates");
+    let cfg = Config::new()
+        .with_out_dir(&dir)
+        .with_auto_namespace(true);
+
+    NsTypeA::export_all(&cfg).unwrap();
+    NsTypeB::export_all(&cfg).unwrap();
+
+    let path_a = dir.join("crate_a/NsColliding.ts");
+    let path_b = dir.join("crate_b/NsColliding.ts");
+
+    assert!(path_a.exists(), "crate_a/NsColliding.ts should exist");
+    assert!(path_b.exists(), "crate_b/NsColliding.ts should exist");
+
+    let content_a = std::fs::read_to_string(&path_a).unwrap();
+    let content_b = std::fs::read_to_string(&path_b).unwrap();
+
+    assert!(content_a.contains("a: string"), "crate_a should have NsTypeA's content");
+    assert!(content_b.contains("b: number"), "crate_b should have NsTypeB's content");
+}
+
+#[test]
+fn auto_namespace_import_paths() {
+    let dir = unique_dir("import_paths");
+    let cfg = Config::new()
+        .with_out_dir(&dir)
+        .with_auto_namespace(true);
+
+    NsParent::export_all(&cfg).unwrap();
+
+    let parent_path = dir.join("parent_crate/NsParent.ts");
+    assert!(parent_path.exists(), "parent_crate/NsParent.ts should exist");
+
+    let content = std::fs::read_to_string(&parent_path).unwrap();
+    assert!(
+        content.contains("../dep_crate/NsDep"),
+        "import path should reference ../dep_crate/NsDep, got:\n{content}"
+    );
+}
+
+#[test]
+fn auto_namespace_off_still_errors() {
+    let dir = unique_dir("off_still_errors");
+    let cfg = Config::new()
+        .with_out_dir(&dir)
+        .with_auto_namespace(false);
+
+    NsTypeA::export_all(&cfg).unwrap();
+    let result = NsTypeB::export_all(&cfg);
+
+    assert!(
+        matches!(result, Err(ExportError::Collision { .. })),
+        "expected Collision error without auto_namespace, got: {result:?}"
+    );
+}
+
+#[test]
+fn auto_namespace_hyphen_to_underscore() {
+    let dir = unique_dir("hyphen_to_underscore");
+    let cfg = Config::new()
+        .with_out_dir(&dir)
+        .with_auto_namespace(true);
+
+    NsHyphenType::export_all(&cfg).unwrap();
+
+    let path = dir.join("my_crate/NsHyphenType.ts");
+    assert!(
+        path.exists(),
+        "my_crate/NsHyphenType.ts should exist (hyphen converted to underscore)"
+    );
+}

--- a/ts-rs/tests/integration/collision.rs
+++ b/ts-rs/tests/integration/collision.rs
@@ -1,0 +1,40 @@
+use ts_rs::TS;
+
+#[derive(TS)]
+#[ts(rename = "Idempotent", export_to = "collision/Idempotent.ts")]
+struct Idempotent {
+    a: String,
+}
+
+#[derive(TS)]
+#[ts(rename = "Colliding", export_to = "collision/Colliding.ts")]
+struct CollidingA {
+    x: i32,
+}
+
+#[derive(TS)]
+#[ts(rename = "Colliding", export_to = "collision/Colliding.ts")]
+struct CollidingB {
+    y: bool,
+    z: String,
+}
+
+#[test]
+fn idempotent_export() {
+    let cfg = ts_rs::Config::default();
+    Idempotent::export_all(&cfg).unwrap();
+    // Second export of the exact same type should succeed
+    Idempotent::export_all(&cfg).unwrap();
+}
+
+#[test]
+fn collision_is_detected() {
+    let cfg = ts_rs::Config::default();
+    CollidingA::export_all(&cfg).unwrap();
+    let err = CollidingB::export_all(&cfg).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Colliding"),
+        "error should mention the colliding type name, got: {msg}"
+    );
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod arrayvec;
 mod bound;
 mod bson;
 mod chrono;
+mod collision;
 mod complex_flattened_type;
 mod concrete_generic;
 mod docs;

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use ts_rs::{Config, TS};
 
+mod auto_namespace;
 mod arrays;
 mod arrayvec;
 mod bound;


### PR DESCRIPTION
## Summary

Follow-up to #483 (collision detection). When `TS_RS_AUTO_NAMESPACE=true` (or `Config::with_auto_namespace(true)`), all exported types are organized into `{crate_name}/` subdirectories based on the crate that defined them, preventing name collisions entirely.

- Adds `crate_name()` to the `TS` trait (returns `None` by default, derive macro generates `Some(env!("CARGO_PKG_NAME"))`)
- Adds `auto_namespace` field to `Config` with env var `TS_RS_AUTO_NAMESPACE` and builder method
- Applies namespace prefix in `export_into`, `TS::export`, `generate_imports`, and `Dependency::from_ty` so file paths and import paths are all correct
- Hyphens in crate names are converted to underscores for directory names
- Updates `Collision` error message to suggest `TS_RS_AUTO_NAMESPACE=true` as an alternative
- 4 integration tests with manual `TS` impls simulating cross-crate behavior

**Design choice:** when enabled, *all* types are namespaced (not just colliding ones). This is deterministic, single-pass, and avoids the circular problem of retroactively rewriting imports after moving files.

## Test plan

- [x] `cargo test --all-features --test integration auto_namespace` — 4 new tests pass
- [x] `cargo test --all-features --test integration collision` — existing collision tests pass
- [x] `cargo test --all-features --test integration same_file_export` — same-file merging unaffected
- [x] `cargo test --all-features` — full suite (532 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)