### PR TITLE
Fix non-deterministic proc-macro output by replacing HashSet with Ind…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
 name = "ts-rs-macros"
 version = "12.0.1"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,7 @@ no-serde-warnings = []
 proc-macro = true
 
 [dependencies]
+indexmap = "2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2.0.28", features = ["full", "extra-traits"] }

--- a/macros/src/deps.rs
+++ b/macros/src/deps.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashSet, rc::Rc};
+use std::rc::Rc;
+
+use indexmap::IndexSet;
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
@@ -6,8 +8,8 @@ use syn::{Path, Type};
 
 pub struct Dependencies {
     crate_rename: Rc<Path>,
-    dependencies: HashSet<Dependency>,
-    types: HashSet<Rc<Type>>,
+    dependencies: IndexSet<Dependency>,
+    types: IndexSet<Rc<Type>>,
 }
 
 #[derive(Hash, Eq, PartialEq)]
@@ -30,9 +32,9 @@ enum Dependency {
 impl Dependencies {
     pub fn new(crate_rename: Path) -> Self {
         Self {
-            dependencies: HashSet::new(),
+            dependencies: IndexSet::new(),
             crate_rename: Rc::new(crate_rename),
-            types: HashSet::new(),
+            types: IndexSet::new(),
         }
     }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,9 @@
 #![macro_use]
 #![deny(unused)]
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use indexmap::IndexSet;
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -442,7 +444,7 @@ fn generate_where_clause(
     let used_types = {
         let is_type_param = |id: &Ident| generics.type_params().any(|p| &p.ident == id);
 
-        let mut used_types = HashSet::new();
+        let mut used_types = IndexSet::new();
         for ty in dependencies.used_types() {
             used_type_params(&mut used_types, ty, is_type_param);
         }
@@ -459,7 +461,7 @@ fn generate_where_clause(
 // Associated types of a type parameter are extracted as well.
 // Note: This will not extract `I` from `I::Item`, but just `I::Item`!
 fn used_type_params<'ty, 'out>(
-    out: &'out mut HashSet<&'ty Type>,
+    out: &'out mut IndexSet<&'ty Type>,
     ty: &'ty Type,
     is_type_param: impl Fn(&'ty Ident) -> bool + Copy + 'out,
 ) {


### PR DESCRIPTION
## Goal

Meta uses remote execution / distributed builds for rust code (using buck2). This makes our builds susceptible to cache invalidation & build consistency issues. We found that `ts-rs` proc-macros were generated non-deterministic token streams due to the use of HashSet/HashMap unordered containers. 

HashSet iteration order depends on RandomState, which is seeded randomly per process. This caused visit_dependencies statements and where-clause predicates to be emitted in different orders across rustc invocations, breaking build caching and reproducibility.

I discovered this issue internally with buck, but a repro can be made by writing a test like so:

```
use ts_rs::{Config, TS};

#[derive(TS)]
struct DeterministicMultiGeneric<A, B, C> {
    a: A,
    b: B,
    c: C,
    nested: Vec<A>,
}

/// Run this test many times (it will always pass in a single process since the
/// hash seed is fixed per process)
#[test]
fn deterministic_decl_output() {
    let cfg = Config::from_env();
    assert_eq!(
        DeterministicMultiGeneric::<(), (), ()>::decl(&cfg),
        "type DeterministicMultiGeneric<A, B, C> = { a: A, b: B, c: C, nested: Array<A>, };"
    );
}

#[derive(TS)]
enum DeterministicEnum<X, Y> {
    First(X),
    Second(Y),
    Both { x: X, y: Y },
}

#[test]
fn deterministic_enum_decl_output() {
    let cfg = Config::from_env();
    assert_eq!(
        DeterministicEnum::<(), ()>::decl(&cfg),
        r#"type DeterministicEnum<X, Y> = { "First": X } | { "Second": Y } | { "Both": { x: X, y: Y, } };"#
    );
}
```

Run this test enough times and it will fail without this PR.
## Changes

Replace HashSet with IndexSet (from indexmap) in deps.rs and lib.rs to preserve insertion order. Alternatively, we could define a specific ordering with `Ord` and use `BTreeSet`/`BTreeMap`, etc. This is the minimal change to fix my issue, however I did notice there are a few more instances of HashMap/HashSet in the proc macro layer. Pending agreement on the approach, I could extend the PR to cover those case.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [*] I have added or updated the tests related to the changes made.

I didn't commit the test here, namely because the test is not reliable; it requires multiple runs to find the breakage, making pinning inconsistent. This could cause unwarranted noise on unrelated PRs in case a breakage does make its way back into the codebase. Open to feedback here.