### PR TITLE
use ts_name for ordering

### DIFF
--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -551,7 +551,7 @@ pub trait TypeVisitor: Sized {
 
 /// A typescript type which is depended upon by other types.
 /// This information is required for generating the correct import statements.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Dependency {
     /// Type ID of the rust type
     pub type_id: TypeId,
@@ -561,6 +561,21 @@ pub struct Dependency {
     /// name, which can be customized with `#[ts(export_to = "..")]`.
     /// This path does _not_ include a base directory.
     pub output_path: PathBuf,
+}
+
+impl Ord for Dependency {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.output_path
+            .cmp(&other.output_path)
+            .then_with(|| self.ts_name.cmp(&other.ts_name))
+            .then_with(|| self.type_id.cmp(&other.type_id))
+    }
+}
+
+impl PartialOrd for Dependency {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl Dependency {


### PR DESCRIPTION
## Goal

Trying to get rid of export re-ordering in different environments. 
## Changes

Use  `ts_name` to compare for ordering before `type_id`. Based on https://github.com/Aleph-Alpha/ts-rs/pull/486 since that seemingly added a test for re-ordering.


## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
