### PR TITLE
Recognize #[serde(deny_unknown_fields)] on enums (mirrors #157 for structs)

### DIFF
--- a/macros/src/attr/enum.rs
+++ b/macros/src/attr/enum.rs
@@ -8,7 +8,10 @@ use super::{
     parse_assign_expr, parse_assign_from_str, parse_bound, parse_repr, Attr, ContainerAttr, Serde,
 };
 use crate::{
-    attr::{parse_assign_inflection, parse_assign_str, parse_concrete, Inflection},
+    attr::{
+        parse_assign_inflection, parse_assign_str, parse_concrete, parse_optional_assign_str,
+        Inflection,
+    },
     optional::{parse_optional, Optional},
     utils::{extract_docs, parse_attrs},
 };
@@ -289,6 +292,11 @@ impl_parse! {
         "content" => out.0.content = Some(parse_assign_str(input)?),
         "untagged" => out.0.untagged = true,
         "bound" => out.0.bound = Some(parse_bound(input)?),
+        // parse #[serde(deny_unknown_fields)] and #[serde(default)] to not
+        // emit a warning (mirrors the StructAttr handling from PR #157).
+        "deny_unknown_fields" | "default" => {
+            parse_optional_assign_str(input)?;
+        },
 
         // parse #[serde(crate = "...")] to not emit a warning
         "crate" => {


### PR DESCRIPTION
## Problem

[#157](https://github.com/Aleph-Alpha/ts-rs/pull/157) taught `Serde<StructAttr>` to parse `deny_unknown_fields` and `default` as no-ops so ts-rs would stop warning about them on structs. Enums were missed — `Serde<EnumAttr>` in `macros/src/attr/enum.rs` still routes both attributes to the catch-all warning branch, so every TS-derived enum that carries `#[serde(deny_unknown_fields)]` emits

    warning: failed to parse serde attribute
      | 
      | deny_unknown_fields 
      | 
      = note: ts-rs failed to parse this attribute. It will be ignored.

at each compile.

This is a real use case for strict wire contracts: an internally-tagged enum that wants both `#[derive(TS)]` and `#[serde(tag = "type", deny_unknown_fields)]` to reject unknown top-level fields at deserialize time.

## Fix

Mirror the [#157](https://github.com/Aleph-Alpha/ts-rs/pull/157) parse-and-drop treatment from `StructAttr` onto `EnumAttr`. One-line change plus the import of `parse_optional_assign_str`.

## Testing

Local verification on a reproducer enum that combines `#[derive(TS, Deserialize, Serialize)]` with `#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]`: previously emits 2 'failed to parse serde attribute' warnings per compile; with this patch emits 0.