### PR TITLE
Implementing astrolabe compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrolabe"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce4de37eb70265f1fe35d8d39a63d3b7ff1a71284dbb2d1fd72ca5766e7409f"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1504,7 @@ name = "ts-rs"
 version = "12.0.1"
 dependencies = [
  "arrayvec",
+ "astrolabe",
  "bigdecimal",
  "bson",
  "bytes",

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ We are currently waiting for [#54140](https://github.com/rust-lang/rust/issues/5
 | tokio-impl         | Implement `TS` for types from *tokio*                                                                                                               |
 | jiff-impl          | Implement `TS` for types from *jiff*                                                                                                                |
 | arrayvec-impl      | Implement `TS` for types from *arrayvec*                                                                                                            |
+| astrolabe-impl     | Implement `TS` for types from *astrolabe*
 
 ### Contributing
 Contributions are always welcome!

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -38,6 +38,7 @@ no-serde-warnings = ["ts-rs-macros/no-serde-warnings"]
 tokio-impl = ["tokio"]
 jiff-impl = ["jiff"]
 arrayvec-impl = ["arrayvec"]
+astrolabe-impl = ["dep:astrolabe"]
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
@@ -65,3 +66,4 @@ serde_json = { version = "1", optional = true }
 tokio = { version = "1", features = ["sync"], optional = true }
 jiff = { version = "0.2", optional = true }
 arrayvec = { version = ">= 0.6, < 0.8", optional = true }
+astrolabe = { version = "0.5.4", optional = true }

--- a/ts-rs/src/astrolabe.rs
+++ b/ts-rs/src/astrolabe.rs
@@ -1,0 +1,9 @@
+use astrolabe::{
+    Date, DateTime, Time
+};
+
+use super::{impl_primitives, TS};
+
+impl_primitives!(Date, DateTime, Time => "string");
+
+

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -123,6 +123,7 @@
 //! | tokio-impl         | Implement `TS` for types from *tokio*                                                                                                               |
 //! | jiff-impl          | Implement `TS` for types from *jiff*                                                                                                                |
 //! | arrayvec-impl      | Implement `TS` for types from *arrayvec*                                                                                                            |
+//! | astrolabe-impl     | Implement `TS` for types from *astrolabe*
 //!
 //! ## Contributing
 //! Contributions are always welcome!

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -148,6 +148,8 @@ pub use ts_rs_macros::TS;
 
 pub use crate::export::ExportError;
 
+#[cfg(feature = "astrolabe-impl")]
+mod astrolabe;
 #[cfg(feature = "chrono-impl")]
 mod chrono;
 mod export;

--- a/ts-rs/tests/integration/astrolabe.rs
+++ b/ts-rs/tests/integration/astrolabe.rs
@@ -1,0 +1,20 @@
+#![cfg(feature = "astrolabe-impl")]
+use astrolabe::{Date, DateTime, Time};
+use ts_rs::{Config, TS};
+
+#[derive(TS)]
+#[ts(export, export_to = "astrolabe/")]
+struct Astrolabe {
+    date: Date,
+    time: Time,
+    date_time: DateTime,
+}
+
+#[test]
+fn astrolabe() {
+    let cfg = Config::from_env();
+    assert_eq!(
+        Astrolabe::decl(&cfg),
+        "type Astrolabe = { date: string, time: string, date_time: string, };"
+    )
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -6,6 +6,7 @@ use ts_rs::{Config, TS};
 
 mod arrays;
 mod arrayvec;
+mod astrolabe;
 mod bound;
 mod bson;
 mod chrono;


### PR DESCRIPTION
## Goal

Implements a new `astrolabe-impl` feature for compatibility with [astrolabe](https://docs.rs/astrolabe/latest/astrolabe/) type `Date`, `DateTime` and `Time`.


## Changes

I mimicked the implementations for other crates. I added an integrations test guarded by the `astrolabe-impl` feature.

My only doubt is about auto-format. I tried running it locally, but it formats many other files I haven't edited. Should I apply the autoformat to the whole crate or only to the files I modified/created?

## Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [X] I have added or updated the tests related to the changes made.
