### PR TITLE
Bump latest compatible heapless to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",

--- a/ts-rs/Cargo.toml
+++ b/ts-rs/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { version = "1.40", features = ["sync", "rt"] }
 ts-rs-macros = { version = "=12.0.1", path = "../macros" }
 thiserror = "2"
 
-heapless = { version = ">= 0.7, < 0.9", optional = true }
+heapless = { version = ">= 0.7, < 0.10", optional = true }
 dprint-plugin-typescript = { version = "= 0.95", optional = true }
 chrono = { version = "0.4", optional = true }
 bigdecimal = { version = ">= 0.0.13, < 0.5", features = ["serde"], optional = true }


### PR DESCRIPTION
## Goal
Make `ts-rs` compatible with `heapless 0.9.3`

## Changes

Bumped the dependency - It appears to work with no modifications to the code. `cargo update heapless`.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made. (N/A)
- [x] I have added or updated the tests related to the changes made. (N/A)
