### PR TITLE
Support `heapless::String`

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -72,7 +72,7 @@ impl DerivedTS {
         let docs = match &*self.docs {
             [] => None,
             docs => Some(quote! {
-                fn docs() -> Option<String> {
+                fn docs() -> Option<::std::string::String> {
                     Some(#crate_rename::format_docs(&[#(#docs),*]))
                 }
             }),
@@ -102,7 +102,7 @@ impl DerivedTS {
 
                 const IS_ENUM: bool = #is_enum;
 
-                fn ident(cfg: &#crate_rename::Config) -> String {
+                fn ident(cfg: &#crate_rename::Config) -> ::std::string::String {
                     (#ident).to_string()
                 }
 
@@ -178,11 +178,11 @@ impl DerivedTS {
                 impl #crate_rename::TS for #generics {
                     type WithoutGenerics = #generics;
                     type OptionInnerType = Self;
-                    fn name(cfg: &#crate_rename::Config) -> String { stringify!(#generics).to_owned() }
-                    fn inline(cfg: &#crate_rename::Config) -> String { panic!("{} cannot be inlined", #name) }
-                    fn inline_flattened(cfg: &#crate_rename::Config) -> String { stringify!(#generics).to_owned() }
-                    fn decl(cfg: &#crate_rename::Config) -> String { panic!("{} cannot be declared", #name) }
-                    fn decl_concrete(cfg: &#crate_rename::Config) -> String { panic!("{} cannot be declared", #name) }
+                    fn name(cfg: &#crate_rename::Config) -> ::std::string::String { stringify!(#generics).to_owned() }
+                    fn inline(cfg: &#crate_rename::Config) -> ::std::string::String { panic!("{} cannot be inlined", #name) }
+                    fn inline_flattened(cfg: &#crate_rename::Config) -> ::std::string::String { stringify!(#generics).to_owned() }
+                    fn decl(cfg: &#crate_rename::Config) -> ::std::string::String { panic!("{} cannot be declared", #name) }
+                    fn decl_concrete(cfg: &#crate_rename::Config) -> ::std::string::String { panic!("{} cannot be declared", #name) }
                 }
             )*
         }
@@ -237,7 +237,7 @@ impl DerivedTS {
         let crate_rename = &self.crate_rename;
         let name = self.name_with_generics(generics);
         quote! {
-            fn name(cfg: &#crate_rename::Config) -> String {
+            fn name(cfg: &#crate_rename::Config) -> ::std::string::String {
                 #name
             }
         }
@@ -265,7 +265,7 @@ impl DerivedTS {
                     return "never".into()
                 }
 
-                let mut buffer = String::new();
+                let mut buffer = ::std::string::String::new();
                 let mut latest = None::<isize>;
 
                 for variant in variants {
@@ -288,7 +288,7 @@ impl DerivedTS {
                     return "never".into()
                 }
 
-                let mut buffer = String::new();
+                let mut buffer = ::std::string::String::new();
                 for variant in variants {
                     buffer.push_str(&variant);
                     buffer.push_str(" | ");
@@ -300,11 +300,11 @@ impl DerivedTS {
         };
 
         quote! {
-            fn inline(cfg: &#crate_rename::Config) -> String {
+            fn inline(cfg: &#crate_rename::Config) -> ::std::string::String {
                 #inline
             }
 
-            fn inline_flattened(cfg: &#crate_rename::Config) -> String {
+            fn inline_flattened(cfg: &#crate_rename::Config) -> ::std::string::String {
                 #inline_flattened
             }
         }
@@ -321,11 +321,11 @@ impl DerivedTS {
         if self.ts_enum.is_some() {
             let inline = &self.inline;
             return quote! {
-                fn decl_concrete(cfg: &#crate_rename::Config) -> String {
+                fn decl_concrete(cfg: &#crate_rename::Config) -> ::std::string::String {
                     format!("enum {} {{ {} }}", #name, #inline)
                 }
 
-                fn decl(cfg: &#crate_rename::Config) -> String {
+                fn decl(cfg: &#crate_rename::Config) -> ::std::string::String {
                     format!("enum {} {{ {} }}", #name, #inline)
                 }
             };
@@ -356,10 +356,10 @@ impl DerivedTS {
             G::Const(ConstParam { ident, .. }) => Some(quote!(#ident)),
         });
         quote! {
-            fn decl_concrete(cfg: &#crate_rename::Config) -> String {
+            fn decl_concrete(cfg: &#crate_rename::Config) -> ::std::string::String {
                 format!("type {} = {};", #name, <Self as #crate_rename::TS>::inline(cfg))
             }
-            fn decl(cfg: &#crate_rename::Config) -> String {
+            fn decl(cfg: &#crate_rename::Config) -> ::std::string::String {
                 #generic_types
                 let inline = <#rust_ty<#(#generic_idents,)*> as #crate_rename::TS>::inline(cfg);
                 let generics = #ts_generics;

--- a/macros/src/types/named.rs
+++ b/macros/src/types/named.rs
@@ -35,8 +35,8 @@ pub(crate) fn named(attr: &StructAttr, ts_name: Expr, fields: &FieldsNamed) -> R
         )?;
     }
 
-    let fields = quote!(<[String]>::join(&[#(#formatted_fields),*], " "));
-    let flattened = quote!(<[String]>::join(&[#(#flattened_fields),*], " & "));
+    let fields = quote!(<[::std::string::String]>::join(&[#(#formatted_fields),*], " "));
+    let flattened = quote!(<[::std::string::String]>::join(&[#(#flattened_fields),*], " & "));
 
     let inline = match (formatted_fields.len(), flattened_fields.len()) {
         (0, 0) => quote!("{  }".to_owned()),

--- a/ts-rs/src/lib.rs
+++ b/ts-rs/src/lib.rs
@@ -1118,6 +1118,9 @@ impl_shadow!(as HashMap<K, V>: impl<K: TS, V: TS> TS for indexmap::IndexMap<K, V
 #[cfg(feature = "heapless-impl")]
 impl_shadow!(as Vec<T>: impl<T: TS, const N: usize> TS for heapless::Vec<T, N>);
 
+#[cfg(feature = "heapless-impl")]
+impl_shadow!(as String: impl<const N: usize> TS for heapless::String<N>);
+
 #[cfg(feature = "arrayvec-impl")]
 impl_shadow!(as Vec<T>: impl<T: TS, const N: usize> TS for arrayvec::ArrayVec<T, N>);
 

--- a/ts-rs/tests/integration/heapless_string.rs
+++ b/ts-rs/tests/integration/heapless_string.rs
@@ -1,0 +1,24 @@
+#![cfg(feature = "heapless-impl")]
+// Import `heapless::String` directly so that the bare identifier `String` is
+// shadowed within this module. This mirrors idiomatic heapless usage and is a
+// regression test: the `TS` derive macro must emit `::std::string::String` in
+// the code it generates, otherwise it resolves to `heapless::String` (a type
+// alias requiring a generic argument) and fails to compile.
+use heapless::{String, Vec};
+use ts_rs::{Config, TS};
+
+#[derive(TS)]
+#[ts(export, export_to = "heapless_string/")]
+struct ImStackAllocated {
+    name: String<32>,
+    nested: Vec<String<8>, 4>,
+}
+
+#[test]
+fn heapless_string() {
+    let cfg = Config::from_env();
+    assert_eq!(
+        ImStackAllocated::decl(&cfg),
+        "type ImStackAllocated = { name: string, nested: Array<string>, };"
+    )
+}

--- a/ts-rs/tests/integration/main.rs
+++ b/ts-rs/tests/integration/main.rs
@@ -78,6 +78,7 @@ mod union_serde;
 mod union_unnamed_serde_skip;
 mod union_with_data;
 mod union_with_internal_tag;
+mod heapless_string;
 mod unit;
 mod r#unsized;
 


### PR DESCRIPTION
## Goal

Type generation for `heapless::String`, unrelated to an existing issue.

## Changes

* Add an `impl_shadow` for `heapless::String`
* Fix shadowing of `String` in macros
* Add a test

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/Aleph-Alpha/ts-rs/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
